### PR TITLE
fix/broken tests nethermind

### DIFF
--- a/simulators/ethereum/engine/clmock/clmock.go
+++ b/simulators/ethereum/engine/clmock/clmock.go
@@ -265,27 +265,13 @@ func (cl *CLMocker) GetTimestampIncrement() uint64 {
 	return cl.BlockTimestampIncrement.Uint64()
 }
 
-var counter = 0
-
 // Returns the timestamp value to be included in the next payload attributes
 func (cl *CLMocker) GetNextBlockTimestamp() uint64 {
-
-	// now := time.Now()
-	// ret := uint64(now.Truncate(time.Minute).Add(time.Duration(cl.GetTimestampIncrement())).Add(time.Duration(counter) * time.Second).Unix())
-	// counter += 1
-	// return ret
 	if cl.FirstPoSBlockNumber == nil && cl.TransitionPayloadTimestamp != nil {
 		// We are producing the transition payload and there's a value specified
 		// for this specific payload
 		return cl.TransitionPayloadTimestamp.Uint64()
 	}
-	// if isShanghai(cl.LatestHeader.Time, cl.ShanghaiTimestamp) && cl.LatestHeader.Time < cl.ShanghaiTimestamp.Uint64() {
-	// 	return cl.ShanghaiTimestamp.Uint64() + cl.GetTimestampIncrement()
-	// }
-
-	// if cl.LatestHeader.Time == 0 {
-	// 	return uint64(time.Now().Unix()) + cl.GetTimestampIncrement()
-	// }
 	return cl.LatestHeader.Time + cl.GetTimestampIncrement()
 }
 

--- a/simulators/ethereum/engine/clmock/clmock.go
+++ b/simulators/ethereum/engine/clmock/clmock.go
@@ -265,7 +265,7 @@ func (cl *CLMocker) GetTimestampIncrement() uint64 {
 	return cl.BlockTimestampIncrement.Uint64()
 }
 
-// Returns the timestamp value to be included in the next payload attributes
+// Returns the next timestamp value to be included in the next payload attributes
 func (cl *CLMocker) GetNextBlockTimestamp() uint64 {
 	if cl.FirstPoSBlockNumber == nil && cl.TransitionPayloadTimestamp != nil {
 		// We are producing the transition payload and there's a value specified

--- a/simulators/ethereum/engine/clmock/clmock.go
+++ b/simulators/ethereum/engine/clmock/clmock.go
@@ -270,16 +270,19 @@ var counter = 0
 // Returns the timestamp value to be included in the next payload attributes
 func (cl *CLMocker) GetNextBlockTimestamp() uint64 {
 
-	now := time.Now()
-	ret := uint64(now.Truncate(time.Minute).Add(5 * time.Second).Add(time.Duration(counter) * time.Second).Unix())
-	counter += 1
-	return ret
+	// now := time.Now()
+	// ret := uint64(now.Truncate(time.Minute).Add(time.Duration(cl.GetTimestampIncrement())).Add(time.Duration(counter) * time.Second).Unix())
+	// counter += 1
+	// return ret
 	//if cl.FirstPoSBlockNumber == nil && cl.TransitionPayloadTimestamp != nil {
 	//	// We are producing the transition payload and there's a value specified
 	//	// for this specific payload
 	//	return cl.TransitionPayloadTimestamp.Uint64()
 	//}
-	//return cl.LatestHeader.Time + cl.GetTimestampIncrement()
+	if isShanghai(cl.LatestHeader.Time, cl.ShanghaiTimestamp) && cl.LatestHeader.Time < cl.ShanghaiTimestamp.Uint64() {
+		return cl.ShanghaiTimestamp.Uint64() + cl.GetTimestampIncrement()
+	}
+	return cl.LatestHeader.Time + cl.GetTimestampIncrement()
 }
 
 // Picks the next payload producer from the set of clients registered

--- a/simulators/ethereum/engine/globals/globals.go
+++ b/simulators/ethereum/engine/globals/globals.go
@@ -1,9 +1,10 @@
 package globals
 
 import (
-	"github.com/ethereum/go-ethereum/crypto"
 	"math/big"
 	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/params"

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -188,7 +188,7 @@ func addTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []test
 						if currentTest.GetTimeout() != 0 {
 							timeout = time.Second * time.Duration(currentTest.GetTimeout())
 						}
-						//time.Sleep(30 * time.Second)
+						time.Sleep(30 * time.Second)
 						// Run the test case
 						test.Run(
 							currentTest,

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -19,6 +19,8 @@ import (
 	suite_withdrawals "github.com/ethereum/hive/simulators/ethereum/engine/suites/withdrawals"
 )
 
+// we will wait that time before every test execution to be sure environment is ready
+// may be changed to other value if necessary
 const SetupTime = 3 * time.Minute
 
 func main() {
@@ -96,6 +98,7 @@ func getTimestamp(spec test.SpecInterface) int64 {
 	}
 
 	preShapellaTime := time.Duration(uint64(preShapellaBlock)*spec.GetBlockTimeIncrements()) * time.Second
+	// after setup wait chain will produce blocks in preShapellaTime and than shapella happens
 	shanghaiTimestamp := now.Add(SetupTime).Add(preShapellaTime)
 	return shanghaiTimestamp.Unix()
 }
@@ -184,7 +187,7 @@ func addTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []test
 						defer func() {
 							t.Logf("End test (%s): %s", c.Type, currentTest.GetName())
 						}()
-						timeout := time.Hour
+						timeout := 30 * time.Minute
 						// If a test.Spec specifies a timeout, use that instead
 						if currentTest.GetTimeout() != 0 {
 							timeout = time.Second * time.Duration(currentTest.GetTimeout())

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -95,7 +95,7 @@ func getTimestamp(spec test.SpecInterface) int64 {
 		preShapellaBlock = 1
 	}
 
-	nextMinute := now.Truncate(time.Minute).Add(time.Duration(preShapellaBlock) * 3 * time.Minute).Add(time.Minute)
+	nextMinute := now.Truncate(time.Minute).Add(time.Duration(preShapellaBlock) * 1 * time.Minute).Add(time.Minute)
 	return nextMinute.Unix()
 }
 
@@ -183,7 +183,7 @@ func addTestsToSuite(sim *hivesim.Simulation, suite *hivesim.Suite, tests []test
 						defer func() {
 							t.Logf("End test (%s): %s", c.Type, currentTest.GetName())
 						}()
-						timeout := time.Minute * 20
+						timeout := time.Hour
 						// If a test.Spec specifies a timeout, use that instead
 						if currentTest.GetTimeout() != 0 {
 							timeout = time.Second * time.Duration(currentTest.GetTimeout())

--- a/simulators/ethereum/engine/main.go
+++ b/simulators/ethereum/engine/main.go
@@ -19,6 +19,8 @@ import (
 	suite_withdrawals "github.com/ethereum/hive/simulators/ethereum/engine/suites/withdrawals"
 )
 
+const SetupTime = 3 * time.Minute
+
 func main() {
 	var (
 		//	engine = hivesim.Suite{
@@ -85,8 +87,6 @@ type ClientGenesis interface {
 	GetTTD()
 }
 
-// Load the genesis based on each client
-
 func getTimestamp(spec test.SpecInterface) int64 {
 	now := time.Now()
 
@@ -95,8 +95,9 @@ func getTimestamp(spec test.SpecInterface) int64 {
 		preShapellaBlock = 1
 	}
 
-	nextMinute := now.Truncate(time.Minute).Add(time.Duration(preShapellaBlock) * 1 * time.Minute).Add(time.Minute)
-	return nextMinute.Unix()
+	preShapellaTime := time.Duration(uint64(preShapellaBlock)*spec.GetBlockTimeIncrements()) * time.Second
+	shanghaiTimestamp := now.Add(SetupTime).Add(preShapellaTime)
+	return shanghaiTimestamp.Unix()
 }
 
 // Add test cases to a given test suite

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -365,7 +365,7 @@ var Tests = []test.SpecInterface{
 			- Spawn a secondary client and send FCUV2(head)
 			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
 			`,
-				TimeoutSeconds: 300,
+				TimeoutSeconds: 3600,
 			},
 			WithdrawalsForkHeight:    2,
 			WithdrawalsBlockCount:    128,

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
-
 	"github.com/ethereum/hive/simulators/ethereum/engine/client/hive_rpc"
 	"github.com/ethereum/hive/simulators/ethereum/engine/clmock"
 	"github.com/ethereum/hive/simulators/ethereum/engine/globals"
@@ -384,9 +383,28 @@ var Tests = []test.SpecInterface{
 				About: `
 				Tests a simple 1 block re-org
 				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 3,
+			WithdrawalsPerBlock:   16,
+		},
+		ReOrgBlockCount: 1,
+		ReOrgViaSync:    false,
+	},
+
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
+				About: `
+				Tests a simple 1 block re-org
+				`,
 				SlotsToSafe:      big.NewInt(32),
 				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
+				TimeoutSeconds:   3600,
 			},
 			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 16,
@@ -395,111 +413,111 @@ var Tests = []test.SpecInterface{
 		ReOrgBlockCount: 1,
 		ReOrgViaSync:    false,
 	},
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
-	// 			About: `
-	// 			Tests a 8 block re-org using NewPayload
-	// 			Re-org does not change withdrawals fork height
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   300,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 16,
-	// 		WithdrawalsPerBlock:   16,
-	// 	},
-	// 	ReOrgBlockCount: 8,
-	// 	ReOrgViaSync:    false,
-	// },
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
-	// 			About: `
-	// 			Tests a 8 block re-org using NewPayload
-	// 			Re-org does not change withdrawals fork height
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   300,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 16,
-	// 		WithdrawalsPerBlock:   16,
-	// 	},
-	// 	ReOrgBlockCount: 8,
-	// 	ReOrgViaSync:    true,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
+				About: `
+				Tests a 8 block re-org using NewPayload
+				Re-org does not change withdrawals fork height
+				`,
+				SlotsToSafe:      big.NewInt(32),
+				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 16,
+			WithdrawalsPerBlock:   16,
+		},
+		ReOrgBlockCount: 8,
+		ReOrgViaSync:    false,
+	},
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
+				About: `
+				Tests a 8 block re-org using NewPayload
+				Re-org does not change withdrawals fork height
+				`,
+				SlotsToSafe:      big.NewInt(32),
+				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 16,
+			WithdrawalsPerBlock:   16,
+		},
+		ReOrgBlockCount: 8,
+		ReOrgViaSync:    true,
+	},
 
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload",
-	// 			About: `
-	// 			Tests a 10 block re-org using NewPayload
-	// 			Re-org does not change withdrawals fork height, but changes
-	// 			the payload at the height of the fork
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 	},
-	// 	ReOrgBlockCount: 10,
-	// 	ReOrgViaSync:    false,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload",
+				About: `
+				Tests a 10 block re-org using NewPayload
+				Re-org does not change withdrawals fork height, but changes
+				the payload at the height of the fork
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+		},
+		ReOrgBlockCount: 10,
+		ReOrgViaSync:    false,
+	},
 
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
-	// 			About: `
-	// 			Tests a 10 block re-org using sync
-	// 			Re-org does not change withdrawals fork height, but changes
-	// 			the payload at the height of the fork
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 	},
-	// 	ReOrgBlockCount: 10,
-	// 	ReOrgViaSync:    true,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
+				About: `
+				Tests a 10 block re-org using sync
+				Re-org does not change withdrawals fork height, but changes
+				the payload at the height of the fork
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+		},
+		ReOrgBlockCount: 10,
+		ReOrgViaSync:    true,
+	},
 
-	// // TODO:
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org",
-	// 			About: `
-	// 			Tests a 10 block re-org using NewPayload
-	// 			Sidechain reaches withdrawals fork at a lower block height
-	// 			than the canonical chain
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 	},
-	// 	ReOrgBlockCount:         10,
-	// 	ReOrgViaSync:            false,
-	// 	SidechainTimeIncrements: 2,
-	// },
+	// TODO:
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org",
+				About: `
+				Tests a 10 block re-org using NewPayload
+				Sidechain reaches withdrawals fork at a lower block height
+				than the canonical chain
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+		},
+		ReOrgBlockCount:         10,
+		ReOrgViaSync:            false,
+		SidechainTimeIncrements: 2,
+	},
 
-	// // TODO:
+	// TODO:
 	&WithdrawalsReorgSpec{
 		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
 			Spec: test.Spec{
@@ -522,53 +540,53 @@ var Tests = []test.SpecInterface{
 		SidechainTimeIncrements: 2,
 	},
 
-	// // TODO:
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org",
-	// 			About: `
-	// 			Tests a 10 block re-org using NewPayload
-	// 			Sidechain reaches withdrawals fork at a higher block height
-	// 			than the canonical chain
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 		TimeIncrements:        2,
-	// 	},
-	// 	ReOrgBlockCount:         10,
-	// 	ReOrgViaSync:            false,
-	// 	SidechainTimeIncrements: 1,
-	// },
+	// TODO:
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org",
+				About: `
+				Tests a 10 block re-org using NewPayload
+				Sidechain reaches withdrawals fork at a higher block height
+				than the canonical chain
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+			TimeIncrements:        2,
+		},
+		ReOrgBlockCount:         10,
+		ReOrgViaSync:            false,
+		SidechainTimeIncrements: 1,
+	},
 
-	// // TODO:
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org Sync",
-	// 			About: `
-	// 			Tests a 10 block re-org using sync
-	// 			Sidechain reaches withdrawals fork at a higher block height
-	// 			than the canonical chain
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 		TimeIncrements:        2,
-	// 	},
-	// 	ReOrgBlockCount:         10,
-	// 	ReOrgViaSync:            true,
-	// 	SidechainTimeIncrements: 1,
-	// },
+	// TODO:
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org Sync",
+				About: `
+				Tests a 10 block re-org using sync
+				Sidechain reaches withdrawals fork at a higher block height
+				than the canonical chain
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+			TimeIncrements:        2,
+		},
+		ReOrgBlockCount:         10,
+		ReOrgViaSync:            true,
+		SidechainTimeIncrements: 1,
+	},
 
 	// TODO: REORG SYNC WHERE SYNCED BLOCKS HAVE WITHDRAWALS BEFORE TIME
 
@@ -1031,6 +1049,22 @@ func (ws *WithdrawalsBaseSpec) waitForShanghai(t *test.Env) {
 	}
 }
 
+func (ws *WithdrawalsBaseSpec) waitForSetup(t *test.Env) {
+	preShapellaBlocksTime := time.Duration(uint64(ws.GetPreShapellaBlockCount())*ws.GetBlockTimeIncrements()) * time.Second
+	setupTimestamp := time.Unix(int64(*t.Genesis.Config().ShanghaiTime), 0).Add(-preShapellaBlocksTime)
+	defer func() {
+		// set genesis timestamp to the end of setup time to increment block times corretly
+		t.CLMock.LatestHeader.Time = uint64(setupTimestamp.Unix())
+	}()
+	if time.Now().Unix() < setupTimestamp.Unix() {
+		durationUntilFuture := time.Until(setupTimestamp)
+		if durationUntilFuture > 0 {
+			t.Logf("INFO: Waiting for setup: ~ %.2f min...", durationUntilFuture.Minutes())
+			time.Sleep(durationUntilFuture)
+		}
+	}
+}
+
 // Base test case execution procedure for withdrawals
 func (ws *WithdrawalsBaseSpec) Execute(t *test.Env) {
 	// Create the withdrawals history object
@@ -1464,11 +1498,11 @@ func (ws *WithdrawalsReorgSpec) Execute(t *test.Env) {
 
 	// Sidechain withdraws on the max account value range 0xffffffffffffffffffffffffffffffffffffffff
 	sidechainStartAccount.Sub(sidechainStartAccount, big.NewInt(int64(ws.GetWithdrawableAccountCount())+1))
-
+	ws.waitForSetup(t)
 	for i := 0; i < int(ws.GetPreWithdrawalsBlockCount()+ws.WithdrawalsBlockCount); i++ {
-		if uint64(i) == ws.GetPreWithdrawalsBlockCount() {
-			ws.waitForShaghai(t)
-		}
+		// if uint64(i) == ws.GetPreWithdrawalsBlockCount() {
+		// 	ws.waitForShaghai(t)
+		// }
 		t.CLMock.ProduceSingleBlock(clmock.BlockProcessCallbacks{
 			OnPayloadProducerSelected: func() {
 				t.CLMock.NextWithdrawals = nil
@@ -1532,10 +1566,8 @@ func (ws *WithdrawalsReorgSpec) Execute(t *test.Env) {
 						Random:                t.CLMock.LatestPayloadAttributes.Random,
 						SuggestedFeeRecipient: t.CLMock.LatestPayloadAttributes.SuggestedFeeRecipient,
 					}
-					// TODO: add shnghai wait to timestamp
-					if t.CLMock.CurrentPayloadNumber == ws.GetSidechainWithdrawalsForkHeight() {
-						pAttributes.Timestamp = shangaiTime
-					} else if t.CLMock.CurrentPayloadNumber > ws.GetSidechainSplitHeight() {
+
+					if t.CLMock.CurrentPayloadNumber > ws.GetSidechainSplitHeight() {
 						pAttributes.Timestamp = sidechain[t.CLMock.CurrentPayloadNumber-1].Timestamp + uint64(ws.GetSidechainBlockTimeIncrements())
 					} else if t.CLMock.CurrentPayloadNumber == ws.GetSidechainSplitHeight() {
 						pAttributes.Timestamp = t.CLMock.LatestHeader.Time + uint64(ws.GetSidechainBlockTimeIncrements())

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -1015,17 +1015,6 @@ func (ws *WithdrawalsBaseSpec) sendPayloadTransactions(t *test.Env) {
 	}
 }
 
-func (ws *WithdrawalsBaseSpec) waitForShanghai(t *test.Env) {
-	if time.Now().Unix() < int64(*t.Genesis.Config().ShanghaiTime) {
-		tUnix := time.Unix(t.CLMock.ShanghaiTimestamp.Int64(), 0)
-		durationUntilFuture := time.Until(tUnix)
-		if durationUntilFuture > 0 {
-			t.Logf("INFO (%s): Waiting for shanghai timestamp: ~ %.2f min", t.TestName, durationUntilFuture.Minutes())
-			time.Sleep(durationUntilFuture)
-		}
-	}
-}
-
 func (ws *WithdrawalsBaseSpec) waitForSetup(t *test.Env) {
 	preShapellaBlocksTime := time.Duration(uint64(ws.GetPreShapellaBlockCount())*ws.GetBlockTimeIncrements()) * time.Second
 	setupTimestamp := time.Unix(int64(*t.Genesis.Config().ShanghaiTime), 0).Add(-preShapellaBlocksTime)
@@ -1456,9 +1445,7 @@ func (ws *WithdrawalsReorgSpec) Execute(t *test.Env) {
 	sidechainStartAccount.Sub(sidechainStartAccount, big.NewInt(int64(ws.GetWithdrawableAccountCount())+1))
 	ws.waitForSetup(t)
 	for i := 0; i < int(ws.GetPreWithdrawalsBlockCount()+ws.WithdrawalsBlockCount); i++ {
-		// if uint64(i) == ws.GetPreWithdrawalsBlockCount() {
-		// 	ws.waitForShaghai(t)
-		// }
+
 		t.CLMock.ProduceSingleBlock(clmock.BlockProcessCallbacks{
 			OnPayloadProducerSelected: func() {
 				t.CLMock.NextWithdrawals = nil

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -3,6 +3,7 @@ package suite_withdrawals
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -91,147 +92,149 @@ var (
 
 // List of all withdrawals tests
 var Tests = []test.SpecInterface{
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Withdawals Fork on Block 1",
-			About: `
-			Tests the withdrawals fork happening on block 1, Block 0 is for Aura.
-			`,
-		},
-		WithdrawalsForkHeight: 1, //TODO
-		WithdrawalsBlockCount: 1, // Genesis is not a withdrawals block
-		WithdrawalsPerBlock:   16,
-		TimeIncrements:        5,
-	},
+	// 	&WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdawals Fork on Block 1",
+	// 			About: `
+	// 			Tests the withdrawals fork happening on block 1, Block 0 is for Aura.
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, //TODO
+	// 		WithdrawalsBlockCount: 1, // Genesis is not a withdrawals block
+	// 		WithdrawalsPerBlock:   16,
+	// 		TimeIncrements:        5,
+	// 	},
 
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Withdrawals Fork on Block 1",
-			About: `
-			Tests the withdrawals fork happening directly after genesis.
-			`,
-		},
-		WithdrawalsForkHeight: 1, // Only Genesis is Pre-Withdrawals
-		WithdrawalsBlockCount: 1,
-		WithdrawalsPerBlock:   16,
-	},
+	// 	&WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1",
+	// 			About: `
+	// 			Tests the withdrawals fork happening directly after genesis.
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Only Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 1,
+	// 		WithdrawalsPerBlock:   16,
+	// 	},
 
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Withdrawals Fork on Block 5",
-			About: `
-			Tests the transition to the withdrawals fork after a single block
-			has happened.
-			Block 1 is sent with invalid non-null withdrawals payload and
-			client is expected to respond with the appropriate error.
-			`,
-		},
-		WithdrawalsForkHeight: 5, // Genesis and Block 1 are Pre-Withdrawals
-		WithdrawalsBlockCount: 1,
-		WithdrawalsPerBlock:   16,
-		TimeIncrements:        5,
-	},
+	// 	&WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 5",
+	// 			About: `
+	// 			Tests the transition to the withdrawals fork after a single block
+	// 			has happened.
+	// 			Block 1 is sent with invalid non-null withdrawals payload and
+	// 			client is expected to respond with the appropriate error.
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight: 5, // Genesis and Block 1 are Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 1,
+	// 		WithdrawalsPerBlock:   16,
+	// 		TimeIncrements:        5,
+	// 	},
 
-	// // TODO: Fix this test. It's reverting the block, which is the expected behavior.
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Withdraw to a single account",
-			About: `
-			Make multiple withdrawals to a single account.
-			`,
-		},
-		WithdrawalsForkHeight:    1,
-		WithdrawalsBlockCount:    1,
-		WithdrawalsPerBlock:      64,
-		WithdrawableAccountCount: 1,
-		TimeIncrements:           5,
-	},
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Withdrawals Fork on Block 3",
+	// 		About: `
+	// 		Tests the transition to the withdrawals fork after two blocks
+	// 		have happened.
+	// 		Block 2 is sent with invalid non-null withdrawals payload and
+	// 		client is expected to respond with the appropriate error.
+	// 		`,
+	// 	},
+	// 	WithdrawalsForkHeight:    3, // Genesis, Block 1 and 2 are Pre-Withdrawals
+	// 	WithdrawalsBlockCount:    1,
+	// 	WithdrawalsPerBlock:      16,
+	// 	TimeIncrements:           5,
+	// 	TestCorrupedHashPayloads: true,
+	// },
 
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Withdraw to a single account",
-			About: `
-			Make multiple withdrawals to a single account.
-			`,
-		},
-		WithdrawalsForkHeight:    1,
-		WithdrawalsBlockCount:    1,
-		WithdrawalsPerBlock:      64,
-		WithdrawableAccountCount: 1,
-	},
+	// 	&WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdraw to a single account",
+	// 			About: `
+	// 			Make multiple withdrawals to a single account.
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight:    1,
+	// 		WithdrawalsBlockCount:    1,
+	// 		WithdrawalsPerBlock:      64,
+	// 		WithdrawableAccountCount: 1,
+	// 	},
 
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Withdraw to two accounts",
-			About: `
-			Make multiple withdrawals to two different accounts, repeated in
-			round-robin.
-			Reasoning: There might be a difference in implementation when an
-			account appears multiple times in the withdrawals list but the list
-			is not in ordered sequence.
-			`,
-		},
-		WithdrawalsForkHeight:    1,
-		WithdrawalsBlockCount:    1,
-		WithdrawalsPerBlock:      64,
-		WithdrawableAccountCount: 2,
-	},
+	// 	&WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdraw to two accounts",
+	// 			About: `
+	// 			Make multiple withdrawals to two different accounts, repeated in
+	// 			round-robin.
+	// 			Reasoning: There might be a difference in implementation when an
+	// 			account appears multiple times in the withdrawals list but the list
+	// 			is not in ordered sequence.
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight:    1,
+	// 		WithdrawalsBlockCount:    1,
+	// 		WithdrawalsPerBlock:      64,
+	// 		WithdrawableAccountCount: 2,
+	// 	},
 
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Withdraw many accounts",
-			About: `
-			Make multiple withdrawals to 1024 different accounts.
-			Execute many blocks this way.
-			`,
-			TimeoutSeconds: 240,
-		},
-		WithdrawalsForkHeight:    1,
-		WithdrawalsBlockCount:    4,
-		WithdrawalsPerBlock:      1024,
-		WithdrawableAccountCount: 1024,
-	},
+	// 	&WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdraw many accounts",
+	// 			About: `
+	// 			Make multiple withdrawals to 1024 different accounts.
+	// 			Execute many blocks this way.
+	// 			`,
+	// 			TimeoutSeconds: 240,
+	// 		},
+	// 		WithdrawalsForkHeight:    1,
+	// 		WithdrawalsBlockCount:    4,
+	// 		WithdrawalsPerBlock:      1024,
+	// 		WithdrawableAccountCount: 1024,
+	// 	},
 
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Withdraw zero amount",
-			About: `
-			Make multiple withdrawals where the amount withdrawn is 0.
-			`,
-		},
-		WithdrawalsForkHeight:    1,
-		WithdrawalsBlockCount:    1,
-		WithdrawalsPerBlock:      64,
-		WithdrawableAccountCount: 2,
-		WithdrawAmounts: []uint64{
-			0,
-			1,
-		},
-	},
+	// 	&WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdraw zero amount",
+	// 			About: `
+	// 			Make multiple withdrawals where the amount withdrawn is 0.
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight:    1,
+	// 		WithdrawalsBlockCount:    1,
+	// 		WithdrawalsPerBlock:      64,
+	// 		WithdrawableAccountCount: 2,
+	// 		WithdrawAmounts: []uint64{
+	// 			0,
+	// 			1,
+	// 		},
+	// 	},
 
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Empty Withdrawals",
-			About: `
-			Produce withdrawals block with zero withdrawals.
-			`,
-		},
-		WithdrawalsForkHeight: 1,
-		WithdrawalsBlockCount: 1,
-		WithdrawalsPerBlock:   0,
-	},
+	// 	&WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Empty Withdrawals",
+	// 			About: `
+	// 			Produce withdrawals block with zero withdrawals.
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight: 1,
+	// 		WithdrawalsBlockCount: 1,
+	// 		WithdrawalsPerBlock:   0,
+	// 	},
 
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Corrupted Block Hash Payload (INVALID)",
-			About: `
-			Send a valid payload with a corrupted hash using engine_newPayloadV2.
-			`,
-		},
-		WithdrawalsForkHeight:    1,
-		WithdrawalsBlockCount:    1,
-		TestCorrupedHashPayloads: true,
-	},
+	// 	&WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Corrupted Block Hash Payload (INVALID)",
+	// 			About: `
+	// 			Send a valid payload with a corrupted hash using engine_newPayloadV2.
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight:    1,
+	// 		WithdrawalsBlockCount:    1,
+	// 		TestCorrupedHashPayloads: true,
+	// 	},
 
 	//Block value tests
 	//&BlockValueSpec{
@@ -247,107 +250,109 @@ var Tests = []test.SpecInterface{
 	//	},
 	//},
 
-	// Sync Tests
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account - No Transactions",
-				About: `
-				- Spawn a first client
-				- Go through withdrawals fork on Block 1
-				- Withdraw to a single account 16 times each block for 2 blocks
-				- Spawn a secondary client and send FCUV2(head)
-				- Wait for sync and verify withdrawn account's balance
-				`,
-				//TimeoutSeconds: 6000,
-			},
-			WithdrawalsForkHeight:    1,
-			WithdrawalsBlockCount:    2,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 1,
-		},
-		SyncSteps: 1,
-	},
+	// // Sync Tests
+	// &WithdrawalsSyncSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account - No Transactions",
+	// 			About: `
+	// 			- Spawn a first client
+	// 			- Go through withdrawals fork on Block 1
+	// 			- Withdraw to a single account 16 times each block for 2 blocks
+	// 			- Spawn a secondary client and send FCUV2(head)
+	// 			- Wait for sync and verify withdrawn account's balance
+	// 			`,
+	// 			//TimeoutSeconds: 6000,
+	// 		},
+	// 		WithdrawalsForkHeight:    1,
+	// 		WithdrawalsBlockCount:    2,
+	// 		WithdrawalsPerBlock:      16,
+	// 		WithdrawableAccountCount: 1,
+	// 	},
+	// 	SyncSteps: 1,
+	// },
 
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account",
-				About: `
-				- Spawn a first client
-				- Go through withdrawals fork on Block 1
-				- Withdraw to a single account 16 times each block for 2 blocks
-				- Spawn a secondary client and send FCUV2(head)
-				- Wait for sync and verify withdrawn account's balance
-				`,
-			},
-			WithdrawalsForkHeight:    1,
-			WithdrawalsBlockCount:    2,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 1,
-		},
-		SyncSteps: 1,
-	},
+	// &WithdrawalsSyncSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account",
+	// 			About: `
+	// 			- Spawn a first client
+	// 			- Go through withdrawals fork on Block 1
+	// 			- Withdraw to a single account 16 times each block for 2 blocks
+	// 			- Spawn a secondary client and send FCUV2(head)
+	// 			- Wait for sync and verify withdrawn account's balance
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight:    1,
+	// 		WithdrawalsBlockCount:    2,
+	// 		WithdrawalsPerBlock:      16,
+	// 		WithdrawableAccountCount: 1,
+	// 	},
+	// 	SyncSteps: 1,
+	// },
 
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 2 blocks - Withdrawals on Genesis - Single Withdrawal Account",
-				About: `
-				- Spawn a first client, with Withdrawals since genesis
-				- Withdraw to a single account 16 times each block for 2 blocks
-				- Spawn a secondary client and send FCUV2(head)
-				- Wait for sync and verify withdrawn account's balance
-				`,
-			},
-			WithdrawalsForkHeight:    0,
-			WithdrawalsBlockCount:    2,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 1,
-		},
-		SyncSteps: 1,
-	},
+	// &WithdrawalsSyncSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Sync after 2 blocks - Withdrawals on Genesis - Single Withdrawal Account",
+	// 			About: `
+	// 			- Spawn a first client, with Withdrawals since genesis
+	// 			- Withdraw to a single account 16 times each block for 2 blocks
+	// 			- Spawn a secondary client and send FCUV2(head)
+	// 			- Wait for sync and verify withdrawn account's balance
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight:    0,
+	// 		WithdrawalsBlockCount:    2,
+	// 		WithdrawalsPerBlock:      16,
+	// 		WithdrawableAccountCount: 1,
+	// 	},
+	// 	SyncSteps: 1,
+	// },
 
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions",
-				About: `
-			- Spawn a first client
-			- Go through withdrawals fork on Block 2
-			- Withdraw to 16 accounts each block for 2 blocks
-			- Spawn a secondary client and send FCUV2(head)
-			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
-			`,
-			},
-			WithdrawalsForkHeight:    2,
-			WithdrawalsBlockCount:    2,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 16,
-			TransactionsPerBlock:     common.Big0,
-		},
-		SyncSteps: 1,
-	},
+	// TODO:
+	// &WithdrawalsSyncSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts - No Transactions",
+	// 			About: `
+	// 		- Spawn a first client
+	// 		- Go through withdrawals fork on Block 2
+	// 		- Withdraw to 16 accounts each block for 2 blocks
+	// 		- Spawn a secondary client and send FCUV2(head)
+	// 		- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
+	// 		`,
+	// 		},
+	// 		WithdrawalsForkHeight:    2,
+	// 		WithdrawalsBlockCount:    2,
+	// 		WithdrawalsPerBlock:      16,
+	// 		WithdrawableAccountCount: 16,
+	// 		TransactionsPerBlock:     common.Big0,
+	// 	},
+	// 	SyncSteps: 1,
+	// },
 
-	&WithdrawalsSyncSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts",
-				About: `
-			- Spawn a first client
-			- Go through withdrawals fork on Block 2
-			- Withdraw to 16 accounts each block for 2 blocks
-			- Spawn a secondary client and send FCUV2(head)
-			- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
-			`,
-			},
-			WithdrawalsForkHeight:    2,
-			WithdrawalsBlockCount:    2,
-			WithdrawalsPerBlock:      16,
-			WithdrawableAccountCount: 16,
-		},
-		SyncSteps: 1,
-	},
+	// TODO:
+	// &WithdrawalsSyncSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Sync after 2 blocks - Withdrawals on Block 2 - Multiple Withdrawal Accounts",
+	// 			About: `
+	// 		- Spawn a first client
+	// 		- Go through withdrawals fork on Block 2
+	// 		- Withdraw to 16 accounts each block for 2 blocks
+	// 		- Spawn a secondary client and send FCUV2(head)
+	// 		- Wait for sync, which include syncing a pre-Withdrawals block, and verify withdrawn account's balance
+	// 		`,
+	// 		},
+	// 		WithdrawalsForkHeight:    2,
+	// 		WithdrawalsBlockCount:    2,
+	// 		WithdrawalsPerBlock:      16,
+	// 		WithdrawableAccountCount: 16,
+	// 	},
+	// 	SyncSteps: 1,
+	// },
 
 	// TODO: This test is failing, need to investigate.
 	&WithdrawalsSyncSpec{
@@ -372,64 +377,64 @@ var Tests = []test.SpecInterface{
 	},
 
 	//Re-Org tests
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
-				About: `
-				Tests a simple 1 block re-org
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
-			},
-			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 16,
-			WithdrawalsPerBlock:   16,
-		},
-		ReOrgBlockCount: 1,
-		ReOrgViaSync:    false,
-	},
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
-				About: `
-				Tests a 8 block re-org using NewPayload
-				Re-org does not change withdrawals fork height
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
-			},
-			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 16,
-			WithdrawalsPerBlock:   16,
-		},
-		ReOrgBlockCount: 8,
-		ReOrgViaSync:    false,
-	},
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
-				About: `
-				Tests a 8 block re-org using NewPayload
-				Re-org does not change withdrawals fork height
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
-			},
-			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 16,
-			WithdrawalsPerBlock:   16,
-		},
-		ReOrgBlockCount: 8,
-		ReOrgViaSync:    true,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
+	// 			About: `
+	// 			Tests a simple 1 block re-org
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   300,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 16,
+	// 		WithdrawalsPerBlock:   16,
+	// 	},
+	// 	ReOrgBlockCount: 1,
+	// 	ReOrgViaSync:    false,
+	// },
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
+	// 			About: `
+	// 			Tests a 8 block re-org using NewPayload
+	// 			Re-org does not change withdrawals fork height
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   300,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 16,
+	// 		WithdrawalsPerBlock:   16,
+	// 	},
+	// 	ReOrgBlockCount: 8,
+	// 	ReOrgViaSync:    false,
+	// },
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
+	// 			About: `
+	// 			Tests a 8 block re-org using NewPayload
+	// 			Re-org does not change withdrawals fork height
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   300,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 16,
+	// 		WithdrawalsPerBlock:   16,
+	// 	},
+	// 	ReOrgBlockCount: 8,
+	// 	ReOrgViaSync:    true,
+	// },
 
-	// TODO:
+	// // TODO:
 	&WithdrawalsReorgSpec{
 		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
 			Spec: test.Spec{
@@ -451,276 +456,276 @@ var Tests = []test.SpecInterface{
 		ReOrgViaSync:    false,
 	},
 
-	// TODO:
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
-				About: `
-				Tests a 10 block re-org using sync
-				Re-org does not change withdrawals fork height, but changes
-				the payload at the height of the fork
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-		},
-		ReOrgBlockCount: 10,
-		ReOrgViaSync:    true,
-	},
+	// // TODO:
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
+	// 			About: `
+	// 			Tests a 10 block re-org using sync
+	// 			Re-org does not change withdrawals fork height, but changes
+	// 			the payload at the height of the fork
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   300,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 	},
+	// 	ReOrgBlockCount: 10,
+	// 	ReOrgViaSync:    true,
+	// },
 
-	// TODO:
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org",
-				About: `
-				Tests a 10 block re-org using NewPayload
-				Sidechain reaches withdrawals fork at a lower block height
-				than the canonical chain
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-		},
-		ReOrgBlockCount:         10,
-		ReOrgViaSync:            false,
-		SidechainTimeIncrements: 2,
-	},
+	// // TODO:
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org",
+	// 			About: `
+	// 			Tests a 10 block re-org using NewPayload
+	// 			Sidechain reaches withdrawals fork at a lower block height
+	// 			than the canonical chain
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   300,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 	},
+	// 	ReOrgBlockCount:         10,
+	// 	ReOrgViaSync:            false,
+	// 	SidechainTimeIncrements: 2,
+	// },
 
-	// TODO:
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org Sync",
-				About: `
-				Tests a 10 block re-org using sync
-				Sidechain reaches withdrawals fork at a lower block height
-				than the canonical chain
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-		},
-		ReOrgBlockCount:         10,
-		ReOrgViaSync:            true,
-		SidechainTimeIncrements: 2,
-	},
+	// // TODO:
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org Sync",
+	// 			About: `
+	// 			Tests a 10 block re-org using sync
+	// 			Sidechain reaches withdrawals fork at a lower block height
+	// 			than the canonical chain
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   300,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 	},
+	// 	ReOrgBlockCount:         10,
+	// 	ReOrgViaSync:            true,
+	// 	SidechainTimeIncrements: 2,
+	// },
 
-	// TODO:
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org",
-				About: `
-				Tests a 10 block re-org using NewPayload
-				Sidechain reaches withdrawals fork at a higher block height
-				than the canonical chain
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-			TimeIncrements:        2,
-		},
-		ReOrgBlockCount:         10,
-		ReOrgViaSync:            false,
-		SidechainTimeIncrements: 1,
-	},
+	// // TODO:
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org",
+	// 			About: `
+	// 			Tests a 10 block re-org using NewPayload
+	// 			Sidechain reaches withdrawals fork at a higher block height
+	// 			than the canonical chain
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   300,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 		TimeIncrements:        2,
+	// 	},
+	// 	ReOrgBlockCount:         10,
+	// 	ReOrgViaSync:            false,
+	// 	SidechainTimeIncrements: 1,
+	// },
 
-	// TODO:
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org Sync",
-				About: `
-				Tests a 10 block re-org using sync
-				Sidechain reaches withdrawals fork at a higher block height
-				than the canonical chain
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-			TimeIncrements:        2,
-		},
-		ReOrgBlockCount:         10,
-		ReOrgViaSync:            true,
-		SidechainTimeIncrements: 1,
-	},
+	// // TODO:
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org Sync",
+	// 			About: `
+	// 			Tests a 10 block re-org using sync
+	// 			Sidechain reaches withdrawals fork at a higher block height
+	// 			than the canonical chain
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   300,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 		TimeIncrements:        2,
+	// 	},
+	// 	ReOrgBlockCount:         10,
+	// 	ReOrgViaSync:            true,
+	// 	SidechainTimeIncrements: 1,
+	// },
 
 	// TODO: REORG SYNC WHERE SYNCED BLOCKS HAVE WITHDRAWALS BEFORE TIME
 
-	//// EVM Tests (EIP-3651, EIP-3855, EIP-3860)
-	//&MaxInitcodeSizeSpec{
+	// EVM Tests (EIP-3651, EIP-3855, EIP-3860)
+	// &MaxInitcodeSizeSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Max Initcode Size",
+	// 		},
+	// 		WithdrawalsForkHeight: 2, // Block 1 is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 2,
+	// 	},
+	// 	OverflowMaxInitcodeTxCountBeforeFork: 0,
+	// 	OverflowMaxInitcodeTxCountAfterFork:  1,
+	// },
+
+	//// Execution layer withdrawals spec
+	// &WithdrawalsExecutionLayerSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 1 blocks withdrawals - 1 mass-claim",
+	// 			About: `
+	// 			- Shapella on block 1
+	// 			- 1 block with withdrawals
+	// 			- Claim accumulated withdrawals
+	// 			- Compares balances and events values with withdrawals from CL
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis and Block 1 are Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 1,
+	// 		WithdrawalsPerBlock:   16,
+	// 		TimeIncrements:        5,
+	// 	},
+	// 	ClaimBlocksCount: 1,
+	// },
+	// &WithdrawalsExecutionLayerSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 2 blocks withdrawals - 2 mass-claims",
+	// 			About: `
+	// 			- Shapella on block 1
+	// 			- 2 blocks with withdrawals
+	// 			- Claim accumulated withdrawals
+	// 			- Produce 1 additional pair (A, B) of blocks:
+	// 			A: block with withdrawals
+	// 			B: block with claim Tx
+	// 			- Compares balances and events values with withdrawals from CL
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis and Block 1 are Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 2,
+	// 		WithdrawalsPerBlock:   16,
+	// 		TimeIncrements:        5,
+	// 	},
+	// 	ClaimBlocksCount: 2,
+	// },
+	// &WithdrawalsExecutionLayerSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 2 - 2 blocks withdrawals - 2 mass-claims",
+	// 			About: `
+	// 			- Shapella on block 2
+	// 			- 2 blocks with withdrawals
+	// 			- Claim accumulated withdrawals
+	// 			- Produce 1 additional pair (A, B) of blocks:
+	// 			A: block with withdrawals
+	// 			B: block with claim Tx
+	// 			- Compares balances and events values with withdrawals from CL
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight: 2,
+	// 		WithdrawalsBlockCount: 2,
+	// 		WithdrawalsPerBlock:   16,
+	// 		TimeIncrements:        5,
+	// 	},
+	// 	ClaimBlocksCount: 2,
+	// },
+	//&WithdrawalsExecutionLayerSpec{
 	//	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
 	//		Spec: test.Spec{
-	//			Name: "Max Initcode Size",
+	//			Name: "Withdrawals Fork on Block 4 - 4 blocks withdrawals - 5 mass-claims - 64 withdrawals per block",
+	//			About: `
+	//			- Shapella on block 4
+	//			- 4 blocks with withdrawals
+	//			- Claim accumulated withdrawals
+	//			- Produce 4 additional pairs (A, B) of blocks:
+	//			  A: block with withdrawals
+	//			  B: block with claim Tx
+	//			- Compares balances and events values with withdrawals from CL
+	//			`,
 	//		},
-	//		WithdrawalsForkHeight: 2, // Block 1 is Pre-Withdrawals
-	//		WithdrawalsBlockCount: 2,
+	//		WithdrawalsForkHeight: 4,
+	//		WithdrawalsBlockCount: 4,
+	//		WithdrawalsPerBlock:   64,
+	//		TimeIncrements:        5,
 	//	},
-	//	OverflowMaxInitcodeTxCountBeforeFork: 0,
-	//	OverflowMaxInitcodeTxCountAfterFork:  1,
+	//	ClaimBlocksCount: 5,
 	//},
-	//
-	// Execution layer withdrawals spec
-	&WithdrawalsExecutionLayerSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 1 blocks withdrawals - 1 mass-claim",
-				About: `
-				- Shapella on block 1
-				- 1 block with withdrawals
-				- Claim accumulated withdrawals
-				- Compares balances and events values with withdrawals from CL
-				`,
-			},
-			WithdrawalsForkHeight: 1, // Genesis and Block 1 are Pre-Withdrawals
-			WithdrawalsBlockCount: 1,
-			WithdrawalsPerBlock:   16,
-			TimeIncrements:        5,
-		},
-		ClaimBlocksCount: 1,
-	},
-	&WithdrawalsExecutionLayerSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 2 blocks withdrawals - 2 mass-claims",
-				About: `
-				- Shapella on block 1
-				- 2 blocks with withdrawals
-				- Claim accumulated withdrawals
-				- Produce 1 additional pair (A, B) of blocks:
-				A: block with withdrawals
-				B: block with claim Tx
-				- Compares balances and events values with withdrawals from CL
-				`,
-			},
-			WithdrawalsForkHeight: 1, // Genesis and Block 1 are Pre-Withdrawals
-			WithdrawalsBlockCount: 2,
-			WithdrawalsPerBlock:   16,
-			TimeIncrements:        5,
-		},
-		ClaimBlocksCount: 2,
-	},
-	&WithdrawalsExecutionLayerSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 2 - 2 blocks withdrawals - 2 mass-claims",
-				About: `
-				- Shapella on block 2
-				- 2 blocks with withdrawals
-				- Claim accumulated withdrawals
-				- Produce 1 additional pair (A, B) of blocks:
-				A: block with withdrawals
-				B: block with claim Tx
-				- Compares balances and events values with withdrawals from CL
-				`,
-			},
-			WithdrawalsForkHeight: 2,
-			WithdrawalsBlockCount: 2,
-			WithdrawalsPerBlock:   16,
-			TimeIncrements:        5,
-		},
-		ClaimBlocksCount: 2,
-	},
-	&WithdrawalsExecutionLayerSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 4 - 4 blocks withdrawals - 5 mass-claims - 64 withdrawals per block",
-				About: `
-				- Shapella on block 4
-				- 4 blocks with withdrawals
-				- Claim accumulated withdrawals
-				- Produce 4 additional pairs (A, B) of blocks:
-				  A: block with withdrawals
-				  B: block with claim Tx
-				- Compares balances and events values with withdrawals from CL
-				`,
-			},
-			WithdrawalsForkHeight: 4,
-			WithdrawalsBlockCount: 4,
-			WithdrawalsPerBlock:   64,
-			TimeIncrements:        5,
-		},
-		ClaimBlocksCount: 5,
-	},
 
-	&WithdrawalsExecutionLayerSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 5",
-				About: `
-				`,
-			},
-			WithdrawalsForkHeight: 5,
-			WithdrawalsBlockCount: 1,
-			WithdrawalsPerBlock:   32,
-			TimeIncrements:        5,
-		},
-		ClaimBlocksCount: 2,
-	},
-	&WithdrawalsExecutionLayerSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 2 - 8 blocks withdrawals - 2 mass-claims - 256 withdrawals per block",
-				About: `
-				- Shapella on block 2
-				- 8 blocks with withdrawals
-				- Claim accumulated withdrawals
-				- Produce 1 additional pair (A, B) of blocks:
-				A: block with withdrawals
-				B: block with claim Tx
-				- Compares balances and events values with withdrawals from CL
-				`,
-			},
-			WithdrawalsForkHeight: 2,
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   256,
-			TimeIncrements:        5,
-		},
-		ClaimBlocksCount: 2,
-	},
-	&WithdrawalsExecutionLayerSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 3 blocks withdrawals - 4 mass-claims - 1024 withdrawals per block",
-				About: `
-				- Shapella on block 1
-				- 3 blocks with withdrawals
-				- Claim accumulated withdrawals
-				- Produce 3 additional pairs (A, B) of blocks:
-				A: block with withdrawals
-				B: block with claim Tx
-				- Compares balances and events values with withdrawals from CL
-				`,
-			},
-			WithdrawalsForkHeight: 1,
-			WithdrawalsBlockCount: 3,
-			WithdrawalsPerBlock:   1024,
-			TimeIncrements:        5,
-		},
-		ClaimBlocksCount: 4,
-	},
+	// &WithdrawalsExecutionLayerSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 5",
+	// 			About: `
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight: 5,
+	// 		WithdrawalsBlockCount: 1,
+	// 		WithdrawalsPerBlock:   32,
+	// 		TimeIncrements:        5,
+	// 	},
+	// 	ClaimBlocksCount: 2,
+	// },
+	// &WithdrawalsExecutionLayerSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 2 - 8 blocks withdrawals - 2 mass-claims - 256 withdrawals per block",
+	// 			About: `
+	// 			- Shapella on block 2
+	// 			- 8 blocks with withdrawals
+	// 			- Claim accumulated withdrawals
+	// 			- Produce 1 additional pair (A, B) of blocks:
+	// 			A: block with withdrawals
+	// 			B: block with claim Tx
+	// 			- Compares balances and events values with withdrawals from CL
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight: 2,
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   256,
+	// 		TimeIncrements:        5,
+	// 	},
+	// 	ClaimBlocksCount: 2,
+	// },
+	// &WithdrawalsExecutionLayerSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 3 blocks withdrawals - 4 mass-claims - 1024 withdrawals per block",
+	// 			About: `
+	// 			- Shapella on block 1
+	// 			- 3 blocks with withdrawals
+	// 			- Claim accumulated withdrawals
+	// 			- Produce 3 additional pairs (A, B) of blocks:
+	// 			A: block with withdrawals
+	// 			B: block with claim Tx
+	// 			- Compares balances and events values with withdrawals from CL
+	// 			`,
+	// 		},
+	// 		WithdrawalsForkHeight: 1,
+	// 		WithdrawalsBlockCount: 3,
+	// 		WithdrawalsPerBlock:   1024,
+	// 		TimeIncrements:        5,
+	// 	},
+	// 	ClaimBlocksCount: 4,
+	// },
 }
 
 // Helper types to convert gwei into wei more easily
@@ -1090,50 +1095,51 @@ func (ws *WithdrawalsBaseSpec) Execute(t *test.Env) {
 				Requested "latest" block expecting block to contain
 				withdrawalRoot=nil, because (block %d).timestamp < shanghaiTime
 				`,
-				t.CLMock.LatestPayloadBuilt.Number,
-			)
-			r.ExpectWithdrawalsRoot(nil)
-		}
-	},
-	OnForkchoiceBroadcast: func() {
-		if !ws.SkipBaseVerifications {
-			ws.VerifyContractsStorage(t)
-		}
-	},
-})
-
-ws.waitForShanghai(t)
-
-var (
-	startAccount = ws.GetWithdrawalsStartAccount()
-	nextIndex    = uint64(0)
-)
-
-// start client
-client := getClient(t)
-if client == nil {
-	t.Fatalf("Couldn't connect to client")
-	return
-}
-defer client.Close()
-
-// Produce requested post-shanghai blocks:
-// 1. Send some withdrawals and transactions
-// 2. Check that contract withdrawable amount matches the expectations
-for i := 0; i < int(ws.WithdrawalsBlockCount); i++ {
-	t.CLMock.ProduceSingleBlock(clmock.BlockProcessCallbacks{
-		OnPayloadProducerSelected: func() {
-			// Send some withdrawals
-			t.CLMock.NextWithdrawals, nextIndex = ws.GenerateWithdrawalsForBlock(nextIndex, startAccount)
-			ws.WithdrawalsHistory[t.CLMock.CurrentPayloadNumber] = t.CLMock.NextWithdrawals
-
-			ws.sendPayloadTransactions(t)
+					t.CLMock.LatestPayloadBuilt.Number,
+				)
+				r.ExpectWithdrawalsRoot(nil)
+			}
 		},
-		OnGetPayload: func() {
+		OnForkchoiceBroadcast: func() {
 			if !ws.SkipBaseVerifications {
+				ws.VerifyContractsStorage(t)
+			}
+		},
+	})
 
-				// Verify the list of withdrawals returned on the payload built
-				// engine_forkchoiceUpdatedV2 method call
+	ws.waitForShaghai(t)
+
+	var (
+		startAccount = ws.GetWithdrawalsStartAccount()
+		nextIndex    = uint64(0)
+	)
+
+	// start client
+	client := getClient(t)
+	if client == nil {
+		t.Fatalf("Couldn't connect to client")
+		return
+	}
+	defer client.Close()
+
+	// Produce requested post-shanghai blocks:
+	// 1. Send some withdrawals and transactions
+	// 2. Check that contract withdrawable amount matches the expectations
+	for i := 0; i < int(ws.WithdrawalsBlockCount); i++ {
+		t.CLMock.ProduceSingleBlock(clmock.BlockProcessCallbacks{
+			OnPayloadProducerSelected: func() {
+				// Send some withdrawals
+				t.CLMock.NextWithdrawals, nextIndex = ws.GenerateWithdrawalsForBlock(nextIndex, startAccount)
+				ws.WithdrawalsHistory[t.CLMock.CurrentPayloadNumber] = t.CLMock.NextWithdrawals
+
+				ws.sendPayloadTransactions(t)
+			},
+			OnGetPayload: func() {
+				if !ws.SkipBaseVerifications {
+
+					// Verify the list of withdrawals returned on the payload built
+					// completely matches the list provided in the
+					// engine_forkchoiceUpdatedV2 method call
 					if sentList, ok := ws.WithdrawalsHistory[t.CLMock.CurrentPayloadNumber]; !ok {
 						t.Fatalf("FAIL (%s): Withdrawals sent list was not saved", t.TestName)
 					} else {
@@ -1153,6 +1159,42 @@ for i := 0; i < int(ws.WithdrawalsBlockCount); i++ {
 					}
 				}
 			},
+			OnNewPayloadBroadcast: func() {
+				// Check withdrawal addresses and verify withdrawal balances
+				// have not yet been applied
+				if !ws.SkipBaseVerifications {
+					for _, addr := range ws.WithdrawalsHistory.GetAddressesWithdrawnOnBlock(t.CLMock.LatestExecutedPayload.Number) {
+						// Test balance at `latest`, which should not yet have the
+						// withdrawal applied.
+						expectedAccountBalance := ws.WithdrawalsHistory.GetExpectedAccumulatedBalance(
+							addr,
+							t.CLMock.LatestExecutedPayload.Number-1)
+						r := t.TestEngine.TestBalanceAt(addr, nil)
+						r.ExpectationDescription = fmt.Sprintf(`
+							Requested balance for account %s on "latest" block
+							after engine_newPayloadV2, expecting balance to be equal
+							to value on previous block (%d), since the new payload
+							has not yet been applied.
+							`,
+							addr,
+							t.CLMock.LatestExecutedPayload.Number-1,
+						)
+						r.ExpectBalanceEqual(expectedAccountBalance)
+					}
+
+					if ws.TestCorrupedHashPayloads {
+						payload := t.CLMock.LatestExecutedPayload
+
+						// Corrupt the hash
+						_, _ = rand.Read(payload.BlockHash[:])
+
+						// On engine_newPayloadV2 `INVALID_BLOCK_HASH` is deprecated
+						// in favor of reusing `INVALID`
+						n := t.TestEngine.TestEngineNewPayloadV2(&payload)
+						n.ExpectStatus(test.Invalid)
+					}
+				}
+			},
 			OnForkchoiceBroadcast: func() {
 				if !ws.SkipBaseVerifications {
 					for _, addr := range ws.WithdrawalsHistory.GetAddressesWithdrawnOnBlock(t.CLMock.LatestExecutedPayload.Number) {
@@ -1162,54 +1204,55 @@ for i := 0; i < int(ws.WithdrawalsBlockCount); i++ {
 							t.Fatalf("FAIL (%s): Error trying to get balance of token: %v, address: %v", t.TestName, err, addr.Hex())
 						}
 
-					expectBalanceMGNO := ws.WithdrawalsHistory.GetExpectedAccumulatedBalance(addr, t.CLMock.LatestExecutedPayload.Number)
-					expectBalance := libgno.UnwrapToGNO(expectBalanceMGNO)
+						expectBalanceMGNO := ws.WithdrawalsHistory.GetExpectedAccumulatedBalance(addr, t.CLMock.LatestExecutedPayload.Number)
+						expectBalance := libgno.UnwrapToGNO(expectBalanceMGNO)
 
-					if withdrawableAmount.Cmp(expectBalance) != 0 {
-						t.Fatalf(
-							"FAIL (%s): Incorrect balance on account %s after withdrawals applied: want=%d, got=%d",
-							t.TestName,
-							addr,
-							expectBalance,
-							withdrawableAmount,
-						)
+						if withdrawableAmount.Cmp(expectBalance) != 0 {
+							t.Fatalf(
+								"FAIL (%s): Incorrect balance on account %s after withdrawals applied: want=%d, got=%d",
+								t.TestName,
+								addr,
+								expectBalance,
+								withdrawableAmount,
+							)
+						}
 					}
+					ws.VerifyContractsStorage(t)
 				}
+			},
+		})
+	}
+
+	// Iterate over balance history of withdrawn accounts using RPC and
+	// check that the balances match expected values.
+	// Also check one block before the withdrawal took place, verify that
+	// withdrawal has not been updated.
+	if !ws.SkipBaseVerifications {
+		for block := uint64(0); block <= t.CLMock.LatestExecutedPayload.Number; block++ {
+			ws.WithdrawalsHistory.VerifyWithdrawals(block, big.NewInt(int64(block)), t.TestEngine)
+
+			// Check the correct withdrawal root on past blocks
+			r := t.TestEngine.TestBlockByNumber(big.NewInt(int64(block)))
+			var expectedWithdrawalsRoot *common.Hash = nil
+			if block >= ws.WithdrawalsForkHeight {
+				calcWithdrawalsRoot := helper.ComputeWithdrawalsRoot(
+					ws.WithdrawalsHistory.GetWithdrawals(block),
+				)
+				expectedWithdrawalsRoot = &calcWithdrawalsRoot
 			}
-		},
-	})
-}
-
-// Iterate over balance history of withdrawn accounts using RPC and
-// check that the balances match expected values.
-// Also check one block before the withdrawal took place, verify that
-// withdrawal has not been updated.
-if !ws.SkipBaseVerifications {
-	for block := uint64(0); block <= t.CLMock.LatestExecutedPayload.Number; block++ {
-		ws.WithdrawalsHistory.VerifyWithdrawals(block, big.NewInt(int64(block)), t.TestEngine)
-
-		// Check the correct withdrawal root on past blocks
-		r := t.TestEngine.TestBlockByNumber(big.NewInt(int64(block)))
-		var expectedWithdrawalsRoot *common.Hash = nil
-		if block >= ws.WithdrawalsForkHeight {
-			calcWithdrawalsRoot := helper.ComputeWithdrawalsRoot(
-				ws.WithdrawalsHistory.GetWithdrawals(block),
-			)
-			expectedWithdrawalsRoot = &calcWithdrawalsRoot
-		}
-		jsWithdrawals, _ := json.MarshalIndent(ws.WithdrawalsHistory.GetWithdrawals(block), "", " ")
-		r.ExpectationDescription = fmt.Sprintf(`
+			jsWithdrawals, _ := json.MarshalIndent(ws.WithdrawalsHistory.GetWithdrawals(block), "", " ")
+			r.ExpectationDescription = fmt.Sprintf(`
 		Requested block %d to verify withdrawalsRoot with the
 		following withdrawals:
 		%s`, block, jsWithdrawals)
 
-		r.ExpectWithdrawalsRoot(expectedWithdrawalsRoot)
+			r.ExpectWithdrawalsRoot(expectedWithdrawalsRoot)
 
+		}
+
+		// Verify on `latest`
+		ws.WithdrawalsHistory.VerifyWithdrawals(t.CLMock.LatestExecutedPayload.Number, nil, t.TestEngine)
 	}
-
-	// Verify on `latest`
-	ws.WithdrawalsHistory.VerifyWithdrawals(t.CLMock.LatestExecutedPayload.Number, nil, t.TestEngine)
-}
 }
 
 func getClient(t *test.Env) *ethclient.Client {
@@ -1311,7 +1354,7 @@ func (ws *WithdrawalsSyncSpec) Execute(t *test.Env) {
 		// TODO
 	} else {
 		// Send the FCU to trigger sync on the secondary client
-		loop:
+	loop:
 		for {
 			select {
 			case <-t.TimeoutContext.Done():
@@ -1592,7 +1635,7 @@ func (ws *WithdrawalsReorgSpec) Execute(t *test.Env) {
 
 	if ws.ReOrgViaSync {
 		// Send latest sidechain payload as NewPayload + FCU and wait for sync
-		loop:
+	loop:
 		for {
 			r := t.TestEngine.TestEngineNewPayloadV2(sidechain[sidechainHeight])
 			r.ExpectNoError()

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -133,22 +133,22 @@ var Tests = []test.SpecInterface{
 	// 		TimeIncrements:        5,
 	// 	},
 
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Withdrawals Fork on Block 3",
-	// 		About: `
-	// 		Tests the transition to the withdrawals fork after two blocks
-	// 		have happened.
-	// 		Block 2 is sent with invalid non-null withdrawals payload and
-	// 		client is expected to respond with the appropriate error.
-	// 		`,
-	// 	},
-	// 	WithdrawalsForkHeight:    3, // Genesis, Block 1 and 2 are Pre-Withdrawals
-	// 	WithdrawalsBlockCount:    1,
-	// 	WithdrawalsPerBlock:      16,
-	// 	TimeIncrements:           5,
-	// 	TestCorrupedHashPayloads: true,
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Withdrawals Fork on Block 3",
+			About: `
+			Tests the transition to the withdrawals fork after two blocks
+			have happened.
+			Block 2 is sent with invalid non-null withdrawals payload and
+			client is expected to respond with the appropriate error.
+			`,
+		},
+		WithdrawalsForkHeight:    3, // Genesis, Block 1 and 2 are Pre-Withdrawals
+		WithdrawalsBlockCount:    1,
+		WithdrawalsPerBlock:      16,
+		TimeIncrements:           5,
+		TestCorrupedHashPayloads: true,
+	},
 
 	// 	&WithdrawalsBaseSpec{
 	// 		Spec: test.Spec{
@@ -377,64 +377,63 @@ var Tests = []test.SpecInterface{
 	},
 
 	//Re-Org tests
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
-	// 			About: `
-	// 			Tests a simple 1 block re-org
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   300,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 16,
-	// 		WithdrawalsPerBlock:   16,
-	// 	},
-	// 	ReOrgBlockCount: 1,
-	// 	ReOrgViaSync:    false,
-	// },
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
-	// 			About: `
-	// 			Tests a 8 block re-org using NewPayload
-	// 			Re-org does not change withdrawals fork height
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   300,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 16,
-	// 		WithdrawalsPerBlock:   16,
-	// 	},
-	// 	ReOrgBlockCount: 8,
-	// 	ReOrgViaSync:    false,
-	// },
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
-	// 			About: `
-	// 			Tests a 8 block re-org using NewPayload
-	// 			Re-org does not change withdrawals fork height
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   300,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 16,
-	// 		WithdrawalsPerBlock:   16,
-	// 	},
-	// 	ReOrgBlockCount: 8,
-	// 	ReOrgViaSync:    true,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
+				About: `
+				Tests a simple 1 block re-org
+				`,
+				SlotsToSafe:      big.NewInt(32),
+				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
+			},
+			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 16,
+			WithdrawalsPerBlock:   16,
+		},
+		ReOrgBlockCount: 1,
+		ReOrgViaSync:    false,
+	},
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
+				About: `
+				Tests a 8 block re-org using NewPayload
+				Re-org does not change withdrawals fork height
+				`,
+				SlotsToSafe:      big.NewInt(32),
+				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
+			},
+			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 16,
+			WithdrawalsPerBlock:   16,
+		},
+		ReOrgBlockCount: 8,
+		ReOrgViaSync:    false,
+	},
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
+				About: `
+				Tests a 8 block re-org using NewPayload
+				Re-org does not change withdrawals fork height
+				`,
+				SlotsToSafe:      big.NewInt(32),
+				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   300,
+			},
+			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 16,
+			WithdrawalsPerBlock:   16,
+		},
+		ReOrgBlockCount: 8,
+		ReOrgViaSync:    true,
+	},
 
-	// // TODO:
 	&WithdrawalsReorgSpec{
 		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
 			Spec: test.Spec{
@@ -444,9 +443,9 @@ var Tests = []test.SpecInterface{
 				Re-org does not change withdrawals fork height, but changes
 				the payload at the height of the fork
 				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
 			},
 			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 			WithdrawalsBlockCount: 8,
@@ -456,27 +455,26 @@ var Tests = []test.SpecInterface{
 		ReOrgViaSync:    false,
 	},
 
-	// // TODO:
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
-	// 			About: `
-	// 			Tests a 10 block re-org using sync
-	// 			Re-org does not change withdrawals fork height, but changes
-	// 			the payload at the height of the fork
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   300,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 	},
-	// 	ReOrgBlockCount: 10,
-	// 	ReOrgViaSync:    true,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
+				About: `
+				Tests a 10 block re-org using sync
+				Re-org does not change withdrawals fork height, but changes
+				the payload at the height of the fork
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+		},
+		ReOrgBlockCount: 10,
+		ReOrgViaSync:    true,
+	},
 
 	// // TODO:
 	// &WithdrawalsReorgSpec{
@@ -488,9 +486,9 @@ var Tests = []test.SpecInterface{
 	// 			Sidechain reaches withdrawals fork at a lower block height
 	// 			than the canonical chain
 	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   300,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
 	// 		},
 	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 	// 		WithdrawalsBlockCount: 8,
@@ -511,9 +509,9 @@ var Tests = []test.SpecInterface{
 	// 			Sidechain reaches withdrawals fork at a lower block height
 	// 			than the canonical chain
 	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   300,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
 	// 		},
 	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 	// 		WithdrawalsBlockCount: 8,
@@ -534,9 +532,9 @@ var Tests = []test.SpecInterface{
 	// 			Sidechain reaches withdrawals fork at a higher block height
 	// 			than the canonical chain
 	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   300,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
 	// 		},
 	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 	// 		WithdrawalsBlockCount: 8,
@@ -558,9 +556,9 @@ var Tests = []test.SpecInterface{
 	// 			Sidechain reaches withdrawals fork at a higher block height
 	// 			than the canonical chain
 	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   300,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
 	// 		},
 	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
 	// 		WithdrawalsBlockCount: 8,
@@ -1027,6 +1025,7 @@ func (ws *WithdrawalsBaseSpec) waitForShanghai(t *test.Env) {
 		tUnix := time.Unix(t.CLMock.ShanghaiTimestamp.Int64(), 0)
 		durationUntilFuture := time.Until(tUnix)
 		if durationUntilFuture > 0 {
+			t.Logf("INFO (%s): Waiting for shanghai timestamp: ~ %.2f min", t.TestName, durationUntilFuture.Minutes())
 			time.Sleep(durationUntilFuture)
 		}
 	}
@@ -1443,9 +1442,11 @@ func (ws *WithdrawalsReorgSpec) GetSidechainWithdrawalsForkHeight() uint64 {
 func (ws *WithdrawalsReorgSpec) Execute(t *test.Env) {
 	// Create the withdrawals history object
 	ws.WithdrawalsHistory = make(WithdrawalsHistory)
+	shangaiTime := *t.Genesis.Config().ShanghaiTime
+	t.CLMock.ShanghaiTimestamp = big.NewInt(0).SetUint64(shangaiTime)
 
 	t.CLMock.WaitForTTD()
-
+	t.Genesis.Config().ShanghaiTime = &shangaiTime
 	// Spawn a secondary client which will produce the sidechain
 	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
 	if err != nil {
@@ -1467,128 +1468,136 @@ func (ws *WithdrawalsReorgSpec) Execute(t *test.Env) {
 	// Sidechain withdraws on the max account value range 0xffffffffffffffffffffffffffffffffffffffff
 	sidechainStartAccount.Sub(sidechainStartAccount, big.NewInt(int64(ws.GetWithdrawableAccountCount())+1))
 
-	t.CLMock.ProduceBlocks(int(ws.GetPreWithdrawalsBlockCount()+ws.WithdrawalsBlockCount), clmock.BlockProcessCallbacks{
-		OnPayloadProducerSelected: func() {
-			t.CLMock.NextWithdrawals = nil
+	for i := 0; i < int(ws.GetPreWithdrawalsBlockCount()+ws.WithdrawalsBlockCount); i++ {
+		if uint64(i) == ws.GetPreWithdrawalsBlockCount() {
+			ws.waitForShaghai(t)
+		}
+		t.CLMock.ProduceSingleBlock(clmock.BlockProcessCallbacks{
+			OnPayloadProducerSelected: func() {
+				t.CLMock.NextWithdrawals = nil
 
-			if t.CLMock.CurrentPayloadNumber >= ws.WithdrawalsForkHeight {
-				// Prepare some withdrawals
-				t.CLMock.NextWithdrawals, canonicalNextIndex = ws.GenerateWithdrawalsForBlock(canonicalNextIndex, canonicalStartAccount)
-				ws.WithdrawalsHistory[t.CLMock.CurrentPayloadNumber] = t.CLMock.NextWithdrawals
-			}
-
-			if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainSplitHeight() {
-				// We have split
-				if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainWithdrawalsForkHeight() {
-					// And we are past the withdrawals fork on the sidechain
-					sidechainWithdrawalsHistory[t.CLMock.CurrentPayloadNumber], sidechainNextIndex = ws.GenerateWithdrawalsForBlock(sidechainNextIndex, sidechainStartAccount)
-				} // else nothing to do
-			} else {
-				// We have not split
-				sidechainWithdrawalsHistory[t.CLMock.CurrentPayloadNumber] = t.CLMock.NextWithdrawals
-				sidechainNextIndex = canonicalNextIndex
-			}
-
-		},
-		OnRequestNextPayload: func() {
-			// Send transactions to be included in the payload
-			txs, err := helper.SendNextTransactions(
-				t.TestContext,
-				t.CLMock.NextBlockProducer,
-				&helper.BaseTransactionCreator{
-					Recipient: &globals.PrevRandaoContractAddr,
-					Amount:    common.Big1,
-					Payload:   nil,
-					TxType:    t.TestTransactionType,
-					GasLimit:  75000,
-				},
-				ws.GetTransactionCountPerPayload(),
-			)
-			if err != nil {
-				t.Fatalf("FAIL (%s): Error trying to send transactions: %v", t.TestName, err)
-			}
-
-			// Error will be ignored here since the tx could have been already relayed
-			secondaryEngine.SendTransactions(t.TestContext, txs)
-
-			if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainSplitHeight() {
-				// Also request a payload from the sidechain
-				fcU := beacon.ForkchoiceStateV1{
-					HeadBlockHash: t.CLMock.LatestForkchoice.HeadBlockHash,
+				if t.CLMock.CurrentPayloadNumber >= ws.WithdrawalsForkHeight {
+					// Prepare some withdrawals
+					t.CLMock.NextWithdrawals, canonicalNextIndex = ws.GenerateWithdrawalsForBlock(canonicalNextIndex, canonicalStartAccount)
+					ws.WithdrawalsHistory[t.CLMock.CurrentPayloadNumber] = t.CLMock.NextWithdrawals
 				}
 
-				if t.CLMock.CurrentPayloadNumber > ws.GetSidechainSplitHeight() {
-					if lastSidePayload, ok := sidechain[t.CLMock.CurrentPayloadNumber-1]; !ok {
-						panic("sidechain payload not found")
-					} else {
-						fcU.HeadBlockHash = lastSidePayload.BlockHash
+				if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainSplitHeight() {
+					// We have split
+					if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainWithdrawalsForkHeight() {
+						// And we are past the withdrawals fork on the sidechain
+						sidechainWithdrawalsHistory[t.CLMock.CurrentPayloadNumber], sidechainNextIndex = ws.GenerateWithdrawalsForBlock(sidechainNextIndex, sidechainStartAccount)
+					} // else nothing to do
+				} else {
+					// We have not split
+					sidechainWithdrawalsHistory[t.CLMock.CurrentPayloadNumber] = t.CLMock.NextWithdrawals
+					sidechainNextIndex = canonicalNextIndex
+				}
+
+			},
+			OnRequestNextPayload: func() {
+				// Send transactions to be included in the payload
+				txs, err := helper.SendNextTransactions(
+					t.TestContext,
+					t.CLMock.NextBlockProducer,
+					&helper.BaseTransactionCreator{
+						Recipient: &globals.PrevRandaoContractAddr,
+						Amount:    common.Big1,
+						Payload:   nil,
+						TxType:    t.TestTransactionType,
+						GasLimit:  75000,
+					},
+					ws.GetTransactionCountPerPayload(),
+				)
+				if err != nil {
+					t.Fatalf("FAIL (%s): Error trying to send transactions: %v", t.TestName, err)
+				}
+
+				// Error will be ignored here since the tx could have been already relayed
+				secondaryEngine.SendTransactions(t.TestContext, txs)
+
+				if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainSplitHeight() {
+					// Also request a payload from the sidechain
+					fcU := beacon.ForkchoiceStateV1{
+						HeadBlockHash: t.CLMock.LatestForkchoice.HeadBlockHash,
 					}
-				}
 
-				var version int
-				pAttributes := beacon.PayloadAttributes{
-					Random:                t.CLMock.LatestPayloadAttributes.Random,
-					SuggestedFeeRecipient: t.CLMock.LatestPayloadAttributes.SuggestedFeeRecipient,
+					if t.CLMock.CurrentPayloadNumber > ws.GetSidechainSplitHeight() {
+						if lastSidePayload, ok := sidechain[t.CLMock.CurrentPayloadNumber-1]; !ok {
+							panic("sidechain payload not found")
+						} else {
+							fcU.HeadBlockHash = lastSidePayload.BlockHash
+						}
+					}
+
+					var version int
+					pAttributes := beacon.PayloadAttributes{
+						Random:                t.CLMock.LatestPayloadAttributes.Random,
+						SuggestedFeeRecipient: t.CLMock.LatestPayloadAttributes.SuggestedFeeRecipient,
+					}
+					// TODO: add shnghai wait to timestamp
+					if t.CLMock.CurrentPayloadNumber == ws.GetSidechainWithdrawalsForkHeight() {
+						pAttributes.Timestamp = shangaiTime
+					} else if t.CLMock.CurrentPayloadNumber > ws.GetSidechainSplitHeight() {
+						pAttributes.Timestamp = sidechain[t.CLMock.CurrentPayloadNumber-1].Timestamp + uint64(ws.GetSidechainBlockTimeIncrements())
+					} else if t.CLMock.CurrentPayloadNumber == ws.GetSidechainSplitHeight() {
+						pAttributes.Timestamp = t.CLMock.LatestHeader.Time + uint64(ws.GetSidechainBlockTimeIncrements())
+					} else {
+						pAttributes.Timestamp = t.CLMock.LatestPayloadAttributes.Timestamp
+					}
+					if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainWithdrawalsForkHeight() {
+						// Withdrawals
+						version = 2
+						pAttributes.Withdrawals = sidechainWithdrawalsHistory[t.CLMock.CurrentPayloadNumber]
+					} else {
+						// No withdrawals
+						version = 1
+					}
+
+					t.Logf("INFO (%s): Requesting sidechain payload %d: %v", t.TestName, t.CLMock.CurrentPayloadNumber, pAttributes)
+
+					r := secondaryEngineTest.TestEngineForkchoiceUpdated(&fcU, &pAttributes, version)
+					r.ExpectNoError()
+					r.ExpectPayloadStatus(test.Valid)
+					if r.Response.PayloadID == nil {
+						t.Fatalf("FAIL (%s): Unable to get a payload ID on the sidechain", t.TestName)
+					}
+					sidechainPayloadId = r.Response.PayloadID
 				}
-				if t.CLMock.CurrentPayloadNumber > ws.GetSidechainSplitHeight() {
-					pAttributes.Timestamp = sidechain[t.CLMock.CurrentPayloadNumber-1].Timestamp + uint64(ws.GetSidechainBlockTimeIncrements())
-				} else if t.CLMock.CurrentPayloadNumber == ws.GetSidechainSplitHeight() {
-					pAttributes.Timestamp = t.CLMock.LatestHeader.Time + uint64(ws.GetSidechainBlockTimeIncrements())
-				} else {
-					pAttributes.Timestamp = t.CLMock.LatestPayloadAttributes.Timestamp
-				}
+			},
+			OnGetPayload: func() {
+				var (
+					version int
+					payload *beacon.ExecutableData
+				)
 				if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainWithdrawalsForkHeight() {
-					// Withdrawals
 					version = 2
-					pAttributes.Withdrawals = sidechainWithdrawalsHistory[t.CLMock.CurrentPayloadNumber]
 				} else {
-					// No withdrawals
 					version = 1
 				}
-
-				t.Logf("INFO (%s): Requesting sidechain payload %d: %v", t.TestName, t.CLMock.CurrentPayloadNumber, pAttributes)
-
-				r := secondaryEngineTest.TestEngineForkchoiceUpdated(&fcU, &pAttributes, version)
-				r.ExpectNoError()
-				r.ExpectPayloadStatus(test.Valid)
-				if r.Response.PayloadID == nil {
-					t.Fatalf("FAIL (%s): Unable to get a payload ID on the sidechain", t.TestName)
+				if t.CLMock.LatestPayloadBuilt.Number >= ws.GetSidechainSplitHeight() {
+					// This payload is built by the secondary client, hence need to manually fetch it here
+					r := secondaryEngineTest.TestEngineGetPayload(sidechainPayloadId, version)
+					r.ExpectNoError()
+					payload = &r.Payload
+					sidechain[payload.Number] = payload
+				} else {
+					// This block is part of both chains, simply forward it to the secondary client
+					payload = &t.CLMock.LatestPayloadBuilt
 				}
-				sidechainPayloadId = r.Response.PayloadID
-			}
-		},
-		OnGetPayload: func() {
-			var (
-				version int
-				payload *beacon.ExecutableData
-			)
-			if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainWithdrawalsForkHeight() {
-				version = 2
-			} else {
-				version = 1
-			}
-			if t.CLMock.LatestPayloadBuilt.Number >= ws.GetSidechainSplitHeight() {
-				// This payload is built by the secondary client, hence need to manually fetch it here
-				r := secondaryEngineTest.TestEngineGetPayload(sidechainPayloadId, version)
-				r.ExpectNoError()
-				payload = &r.Payload
-				sidechain[payload.Number] = payload
-			} else {
-				// This block is part of both chains, simply forward it to the secondary client
-				payload = &t.CLMock.LatestPayloadBuilt
-			}
-			r := secondaryEngineTest.TestEngineNewPayload(payload, version)
-			r.ExpectStatus(test.Valid)
-			p := secondaryEngineTest.TestEngineForkchoiceUpdated(
-				&beacon.ForkchoiceStateV1{
-					HeadBlockHash: payload.BlockHash,
-				},
-				nil,
-				version,
-			)
-			p.ExpectPayloadStatus(test.Valid)
-		},
-	})
+				r := secondaryEngineTest.TestEngineNewPayload(payload, version)
+				r.ExpectStatus(test.Valid)
+				p := secondaryEngineTest.TestEngineForkchoiceUpdated(
+					&beacon.ForkchoiceStateV1{
+						HeadBlockHash: payload.BlockHash,
+					},
+					nil,
+					version,
+				)
+				p.ExpectPayloadStatus(test.Valid)
+			},
+		})
+	}
 
 	sidechainHeight := t.CLMock.LatestExecutedPayload.Number
 

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -179,7 +179,6 @@ var Tests = []test.SpecInterface{
 	// 	WithdrawableAccountCount: 2,
 	// },
 
-	// TODO: panicing with new timestamp increment scheme
 	&WithdrawalsBaseSpec{
 		Spec: test.Spec{
 			Name: "Withdraw many accounts",
@@ -1191,25 +1190,6 @@ func (ws *WithdrawalsBaseSpec) Execute(t *test.Env) {
 				// Check withdrawal addresses and verify withdrawal balances
 				// have not yet been applied
 				if !ws.SkipBaseVerifications {
-					for _, addr := range ws.WithdrawalsHistory.GetAddressesWithdrawnOnBlock(t.CLMock.LatestExecutedPayload.Number) {
-						// Test balance at `latest`, which should not yet have the
-						// withdrawal applied.
-						expectedAccountBalance := ws.WithdrawalsHistory.GetExpectedAccumulatedBalance(
-							addr,
-							t.CLMock.LatestExecutedPayload.Number-1)
-						r := t.TestEngine.TestBalanceAt(addr, nil)
-						r.ExpectationDescription = fmt.Sprintf(`
-							Requested balance for account %s on "latest" block
-							after engine_newPayloadV2, expecting balance to be equal
-							to value on previous block (%d), since the new payload
-							has not yet been applied.
-							`,
-							addr,
-							t.CLMock.LatestExecutedPayload.Number-1,
-						)
-						r.ExpectBalanceEqual(expectedAccountBalance)
-					}
-
 					if ws.TestCorrupedHashPayloads {
 						payload := t.CLMock.LatestExecutedPayload
 

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -91,149 +91,149 @@ var (
 
 // List of all withdrawals tests
 var Tests = []test.SpecInterface{
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Withdawals Fork on Block 1",
-	// 		About: `
-	// 			Tests the withdrawals fork happening on block 1, Block 0 is for Aura.
-	// 			`,
-	// 	},
-	// 	WithdrawalsForkHeight: 1, //TODO
-	// 	WithdrawalsBlockCount: 1, // Genesis is not a withdrawals block
-	// 	WithdrawalsPerBlock:   16,
-	// 	TimeIncrements:        5,
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Withdawals Fork on Block 1",
+			About: `
+				Tests the withdrawals fork happening on block 1, Block 0 is for Aura.
+				`,
+		},
+		WithdrawalsForkHeight: 1, //TODO
+		WithdrawalsBlockCount: 1, // Genesis is not a withdrawals block
+		WithdrawalsPerBlock:   16,
+		TimeIncrements:        5,
+	},
 
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Withdrawals Fork on Block 1",
-	// 		About: `
-	// 			Tests the withdrawals fork happening directly after genesis.
-	// 			`,
-	// 	},
-	// 	WithdrawalsForkHeight: 1, // Only Genesis is Pre-Withdrawals
-	// 	WithdrawalsBlockCount: 1,
-	// 	WithdrawalsPerBlock:   16,
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Withdrawals Fork on Block 1",
+			About: `
+				Tests the withdrawals fork happening directly after genesis.
+				`,
+		},
+		WithdrawalsForkHeight: 1, // Only Genesis is Pre-Withdrawals
+		WithdrawalsBlockCount: 1,
+		WithdrawalsPerBlock:   16,
+	},
 
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Withdrawals Fork on Block 5",
-	// 		About: `
-	// 			Tests the transition to the withdrawals fork after a single block
-	// 			has happened.
-	// 			Block 1 is sent with invalid non-null withdrawals payload and
-	// 			client is expected to respond with the appropriate error.
-	// 			`,
-	// 	},
-	// 	WithdrawalsForkHeight: 5, // Genesis and Block 1 are Pre-Withdrawals
-	// 	WithdrawalsBlockCount: 1,
-	// 	WithdrawalsPerBlock:   16,
-	// 	TimeIncrements:        5,
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Withdrawals Fork on Block 5",
+			About: `
+				Tests the transition to the withdrawals fork after a single block
+				has happened.
+				Block 1 is sent with invalid non-null withdrawals payload and
+				client is expected to respond with the appropriate error.
+				`,
+		},
+		WithdrawalsForkHeight: 5, // Genesis and Block 1 are Pre-Withdrawals
+		WithdrawalsBlockCount: 1,
+		WithdrawalsPerBlock:   16,
+		TimeIncrements:        5,
+	},
 
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Withdrawals Fork on Block 3",
-	// 		About: `
-	// 		Tests the transition to the withdrawals fork after two blocks
-	// 		have happened.
-	// 		Block 2 is sent with invalid non-null withdrawals payload and
-	// 		client is expected to respond with the appropriate error.
-	// 		`,
-	// 	},
-	// 	WithdrawalsForkHeight:    3, // Genesis, Block 1 and 2 are Pre-Withdrawals
-	// 	WithdrawalsBlockCount:    1,
-	// 	WithdrawalsPerBlock:      16,
-	// 	TimeIncrements:           5,
-	// 	TestCorrupedHashPayloads: true,
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Withdrawals Fork on Block 3",
+			About: `
+			Tests the transition to the withdrawals fork after two blocks
+			have happened.
+			Block 2 is sent with invalid non-null withdrawals payload and
+			client is expected to respond with the appropriate error.
+			`,
+		},
+		WithdrawalsForkHeight:    3, // Genesis, Block 1 and 2 are Pre-Withdrawals
+		WithdrawalsBlockCount:    1,
+		WithdrawalsPerBlock:      16,
+		TimeIncrements:           5,
+		TestCorrupedHashPayloads: true,
+	},
 
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Withdraw to a single account",
-	// 		About: `
-	// 			Make multiple withdrawals to a single account.
-	// 			`,
-	// 	},
-	// 	WithdrawalsForkHeight:    1,
-	// 	WithdrawalsBlockCount:    1,
-	// 	WithdrawalsPerBlock:      64,
-	// 	WithdrawableAccountCount: 1,
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Withdraw to a single account",
+			About: `
+				Make multiple withdrawals to a single account.
+				`,
+		},
+		WithdrawalsForkHeight:    1,
+		WithdrawalsBlockCount:    1,
+		WithdrawalsPerBlock:      64,
+		WithdrawableAccountCount: 1,
+	},
 
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Withdraw to two accounts",
-	// 		About: `
-	// 			Make multiple withdrawals to two different accounts, repeated in
-	// 			round-robin.
-	// 			Reasoning: There might be a difference in implementation when an
-	// 			account appears multiple times in the withdrawals list but the list
-	// 			is not in ordered sequence.
-	// 			`,
-	// 	},
-	// 	WithdrawalsForkHeight:    1,
-	// 	WithdrawalsBlockCount:    1,
-	// 	WithdrawalsPerBlock:      64,
-	// 	WithdrawableAccountCount: 2,
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Withdraw to two accounts",
+			About: `
+				Make multiple withdrawals to two different accounts, repeated in
+				round-robin.
+				Reasoning: There might be a difference in implementation when an
+				account appears multiple times in the withdrawals list but the list
+				is not in ordered sequence.
+				`,
+		},
+		WithdrawalsForkHeight:    1,
+		WithdrawalsBlockCount:    1,
+		WithdrawalsPerBlock:      64,
+		WithdrawableAccountCount: 2,
+	},
 
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Withdraw many accounts",
-	// 		About: `
-	// 			Make multiple withdrawals to 1024 different accounts.
-	// 			Execute many blocks this way.
-	// 			`,
-	// 		TimeoutSeconds: 3600,
-	// 	},
-	// 	WithdrawalsForkHeight:    1,
-	// 	WithdrawalsBlockCount:    4,
-	// 	WithdrawalsPerBlock:      1024,
-	// 	WithdrawableAccountCount: 1024,
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Withdraw many accounts",
+			About: `
+				Make multiple withdrawals to 1024 different accounts.
+				Execute many blocks this way.
+				`,
+			TimeoutSeconds: 3600,
+		},
+		WithdrawalsForkHeight:    1,
+		WithdrawalsBlockCount:    4,
+		WithdrawalsPerBlock:      1024,
+		WithdrawableAccountCount: 1024,
+	},
 
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Withdraw zero amount",
-	// 		About: `
-	// 			Make multiple withdrawals where the amount withdrawn is 0.
-	// 			`,
-	// 	},
-	// 	WithdrawalsForkHeight:    1,
-	// 	WithdrawalsBlockCount:    1,
-	// 	WithdrawalsPerBlock:      64,
-	// 	WithdrawableAccountCount: 2,
-	// 	WithdrawAmounts: []uint64{
-	// 		0,
-	// 		1,
-	// 	},
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Withdraw zero amount",
+			About: `
+				Make multiple withdrawals where the amount withdrawn is 0.
+				`,
+		},
+		WithdrawalsForkHeight:    1,
+		WithdrawalsBlockCount:    1,
+		WithdrawalsPerBlock:      64,
+		WithdrawableAccountCount: 2,
+		WithdrawAmounts: []uint64{
+			0,
+			1,
+		},
+	},
 
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Empty Withdrawals",
-	// 		About: `
-	// 			Produce withdrawals block with zero withdrawals.
-	// 			`,
-	// 	},
-	// 	WithdrawalsForkHeight: 1,
-	// 	WithdrawalsBlockCount: 1,
-	// 	WithdrawalsPerBlock:   0,
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Empty Withdrawals",
+			About: `
+				Produce withdrawals block with zero withdrawals.
+				`,
+		},
+		WithdrawalsForkHeight: 1,
+		WithdrawalsBlockCount: 1,
+		WithdrawalsPerBlock:   0,
+	},
 
-	// &WithdrawalsBaseSpec{
-	// 	Spec: test.Spec{
-	// 		Name: "Corrupted Block Hash Payload (INVALID)",
-	// 		About: `
-	// 			Send a valid payload with a corrupted hash using engine_newPayloadV2.
-	// 			`,
-	// 	},
-	// 	WithdrawalsForkHeight:    1,
-	// 	WithdrawalsBlockCount:    1,
-	// 	TestCorrupedHashPayloads: true,
-	// },
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Corrupted Block Hash Payload (INVALID)",
+			About: `
+				Send a valid payload with a corrupted hash using engine_newPayloadV2.
+				`,
+		},
+		WithdrawalsForkHeight:    1,
+		WithdrawalsBlockCount:    1,
+		TestCorrupedHashPayloads: true,
+	},
 
 	//Block value tests
 	//&BlockValueSpec{
@@ -250,65 +250,65 @@ var Tests = []test.SpecInterface{
 	//},
 
 	// Sync Tests
-	// &WithdrawalsSyncSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account - No Transactions",
-	// 			About: `
-	// 			- Spawn a first client
-	// 			- Go through withdrawals fork on Block 1
-	// 			- Withdraw to a single account 16 times each block for 2 blocks
-	// 			- Spawn a secondary client and send FCUV2(head)
-	// 			- Wait for sync and verify withdrawn account's balance
-	// 			`,
-	// 			//TimeoutSeconds: 6000,
-	// 		},
-	// 		WithdrawalsForkHeight:    1,
-	// 		WithdrawalsBlockCount:    2,
-	// 		WithdrawalsPerBlock:      16,
-	// 		WithdrawableAccountCount: 1,
-	// 	},
-	// 	SyncSteps: 1,
-	// },
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account - No Transactions",
+				About: `
+				- Spawn a first client
+				- Go through withdrawals fork on Block 1
+				- Withdraw to a single account 16 times each block for 2 blocks
+				- Spawn a secondary client and send FCUV2(head)
+				- Wait for sync and verify withdrawn account's balance
+				`,
+				//TimeoutSeconds: 6000,
+			},
+			WithdrawalsForkHeight:    1,
+			WithdrawalsBlockCount:    2,
+			WithdrawalsPerBlock:      16,
+			WithdrawableAccountCount: 1,
+		},
+		SyncSteps: 1,
+	},
 
-	// &WithdrawalsSyncSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account",
-	// 			About: `
-	// 			- Spawn a first client
-	// 			- Go through withdrawals fork on Block 1
-	// 			- Withdraw to a single account 16 times each block for 2 blocks
-	// 			- Spawn a secondary client and send FCUV2(head)
-	// 			- Wait for sync and verify withdrawn account's balance
-	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight:    1,
-	// 		WithdrawalsBlockCount:    2,
-	// 		WithdrawalsPerBlock:      16,
-	// 		WithdrawableAccountCount: 1,
-	// 	},
-	// 	SyncSteps: 1,
-	// },
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Sync after 2 blocks - Withdrawals on Block 1 - Single Withdrawal Account",
+				About: `
+				- Spawn a first client
+				- Go through withdrawals fork on Block 1
+				- Withdraw to a single account 16 times each block for 2 blocks
+				- Spawn a secondary client and send FCUV2(head)
+				- Wait for sync and verify withdrawn account's balance
+				`,
+			},
+			WithdrawalsForkHeight:    1,
+			WithdrawalsBlockCount:    2,
+			WithdrawalsPerBlock:      16,
+			WithdrawableAccountCount: 1,
+		},
+		SyncSteps: 1,
+	},
 
-	// &WithdrawalsSyncSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Sync after 2 blocks - Withdrawals on Genesis - Single Withdrawal Account",
-	// 			About: `
-	// 			- Spawn a first client, with Withdrawals since genesis
-	// 			- Withdraw to a single account 16 times each block for 2 blocks
-	// 			- Spawn a secondary client and send FCUV2(head)
-	// 			- Wait for sync and verify withdrawn account's balance
-	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight:    0,
-	// 		WithdrawalsBlockCount:    2,
-	// 		WithdrawalsPerBlock:      16,
-	// 		WithdrawableAccountCount: 1,
-	// 	},
-	// 	SyncSteps: 1,
-	// },
+	&WithdrawalsSyncSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Sync after 2 blocks - Withdrawals on Genesis - Single Withdrawal Account",
+				About: `
+				- Spawn a first client, with Withdrawals since genesis
+				- Withdraw to a single account 16 times each block for 2 blocks
+				- Spawn a secondary client and send FCUV2(head)
+				- Wait for sync and verify withdrawn account's balance
+				`,
+			},
+			WithdrawalsForkHeight:    0,
+			WithdrawalsBlockCount:    2,
+			WithdrawalsPerBlock:      16,
+			WithdrawableAccountCount: 1,
+		},
+		SyncSteps: 1,
+	},
 
 	// // TODO:
 	// &WithdrawalsSyncSpec{
@@ -375,214 +375,195 @@ var Tests = []test.SpecInterface{
 		SyncSteps: 1,
 	},
 
-	// //Re-Org tests
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
-	// 			About: `
-	// 			Tests a simple 1 block re-org
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 3,
-	// 		WithdrawalsPerBlock:   16,
-	// 	},
-	// 	ReOrgBlockCount: 1,
-	// 	ReOrgViaSync:    false,
-	// },
+	// Re-Org tests
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
+				About: `
+				Tests a simple 1 block re-org
+				`,
+				SlotsToSafe:      big.NewInt(32),
+				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 16,
+			WithdrawalsPerBlock:   16,
+		},
+		ReOrgBlockCount: 1,
+		ReOrgViaSync:    false,
+	},
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
+				About: `
+				Tests a 8 block re-org using NewPayload
+				Re-org does not change withdrawals fork height
+				`,
+				SlotsToSafe:      big.NewInt(32),
+				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 16,
+			WithdrawalsPerBlock:   16,
+		},
+		ReOrgBlockCount: 8,
+		ReOrgViaSync:    false,
+	},
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
+				About: `
+				Tests a 8 block re-org using NewPayload
+				Re-org does not change withdrawals fork height
+				`,
+				SlotsToSafe:      big.NewInt(32),
+				SlotsToFinalized: big.NewInt(64),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 16,
+			WithdrawalsPerBlock:   16,
+		},
+		ReOrgBlockCount: 8,
+		ReOrgViaSync:    true,
+	},
 
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
-	// 			About: `
-	// 			Tests a simple 1 block re-org
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 16,
-	// 		WithdrawalsPerBlock:   16,
-	// 	},
-	// 	ReOrgBlockCount: 1,
-	// 	ReOrgViaSync:    false,
-	// },
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
-	// 			About: `
-	// 			Tests a 8 block re-org using NewPayload
-	// 			Re-org does not change withdrawals fork height
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 16,
-	// 		WithdrawalsPerBlock:   16,
-	// 	},
-	// 	ReOrgBlockCount: 8,
-	// 	ReOrgViaSync:    false,
-	// },
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
-	// 			About: `
-	// 			Tests a 8 block re-org using NewPayload
-	// 			Re-org does not change withdrawals fork height
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(32),
-	// 			SlotsToFinalized: big.NewInt(64),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 16,
-	// 		WithdrawalsPerBlock:   16,
-	// 	},
-	// 	ReOrgBlockCount: 8,
-	// 	ReOrgViaSync:    true,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload",
+				About: `
+				Tests a 10 block re-org using NewPayload
+				Re-org does not change withdrawals fork height, but changes
+				the payload at the height of the fork
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+		},
+		ReOrgBlockCount: 10,
+		ReOrgViaSync:    false,
+	},
 
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload",
-	// 			About: `
-	// 			Tests a 10 block re-org using NewPayload
-	// 			Re-org does not change withdrawals fork height, but changes
-	// 			the payload at the height of the fork
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 	},
-	// 	ReOrgBlockCount: 10,
-	// 	ReOrgViaSync:    false,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
+				About: `
+				Tests a 10 block re-org using sync
+				Re-org does not change withdrawals fork height, but changes
+				the payload at the height of the fork
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+		},
+		ReOrgBlockCount: 10,
+		ReOrgViaSync:    true,
+	},
 
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
-	// 			About: `
-	// 			Tests a 10 block re-org using sync
-	// 			Re-org does not change withdrawals fork height, but changes
-	// 			the payload at the height of the fork
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 	},
-	// 	ReOrgBlockCount: 10,
-	// 	ReOrgViaSync:    true,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org",
+				About: `
+				Tests a 10 block re-org using NewPayload
+				Sidechain reaches withdrawals fork at a lower block height
+				than the canonical chain
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+		},
+		ReOrgBlockCount:         10,
+		ReOrgViaSync:            false,
+		SidechainTimeIncrements: 2,
+	},
 
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org",
-	// 			About: `
-	// 			Tests a 10 block re-org using NewPayload
-	// 			Sidechain reaches withdrawals fork at a lower block height
-	// 			than the canonical chain
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 	},
-	// 	ReOrgBlockCount:         10,
-	// 	ReOrgViaSync:            false,
-	// 	SidechainTimeIncrements: 2,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org Sync",
+				About: `
+				Tests a 10 block re-org using sync
+				Sidechain reaches withdrawals fork at a lower block height
+				than the canonical chain
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+		},
+		ReOrgBlockCount:         10,
+		ReOrgViaSync:            true,
+		SidechainTimeIncrements: 2,
+	},
 
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org Sync",
-	// 			About: `
-	// 			Tests a 10 block re-org using sync
-	// 			Sidechain reaches withdrawals fork at a lower block height
-	// 			than the canonical chain
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 	},
-	// 	ReOrgBlockCount:         10,
-	// 	ReOrgViaSync:            true,
-	// 	SidechainTimeIncrements: 2,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org",
+				About: `
+				Tests a 10 block re-org using NewPayload
+				Sidechain reaches withdrawals fork at a higher block height
+				than the canonical chain
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+			TimeIncrements:        2,
+		},
+		ReOrgBlockCount:         10,
+		ReOrgViaSync:            false,
+		SidechainTimeIncrements: 1,
+	},
 
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org",
-	// 			About: `
-	// 			Tests a 10 block re-org using NewPayload
-	// 			Sidechain reaches withdrawals fork at a higher block height
-	// 			than the canonical chain
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 		TimeIncrements:        2,
-	// 	},
-	// 	ReOrgBlockCount:         10,
-	// 	ReOrgViaSync:            false,
-	// 	SidechainTimeIncrements: 1,
-	// },
-
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org Sync",
-	// 			About: `
-	// 			Tests a 10 block re-org using sync
-	// 			Sidechain reaches withdrawals fork at a higher block height
-	// 			than the canonical chain
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 		TimeIncrements:        2,
-	// 	},
-	// 	ReOrgBlockCount:         10,
-	// 	ReOrgViaSync:            true,
-	// 	SidechainTimeIncrements: 1,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org Sync",
+				About: `
+				Tests a 10 block re-org using sync
+				Sidechain reaches withdrawals fork at a higher block height
+				than the canonical chain
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+			TimeIncrements:        2,
+		},
+		ReOrgBlockCount:         10,
+		ReOrgViaSync:            true,
+		SidechainTimeIncrements: 1,
+	},
 
 	// TODO: REORG SYNC WHERE SYNCED BLOCKS HAVE WITHDRAWALS BEFORE TIME
 

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -91,46 +91,46 @@ var (
 
 // List of all withdrawals tests
 var Tests = []test.SpecInterface{
-	// 	&WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdawals Fork on Block 1",
-	// 			About: `
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Withdawals Fork on Block 1",
+	// 		About: `
 	// 			Tests the withdrawals fork happening on block 1, Block 0 is for Aura.
 	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, //TODO
-	// 		WithdrawalsBlockCount: 1, // Genesis is not a withdrawals block
-	// 		WithdrawalsPerBlock:   16,
-	// 		TimeIncrements:        5,
 	// 	},
+	// 	WithdrawalsForkHeight: 1, //TODO
+	// 	WithdrawalsBlockCount: 1, // Genesis is not a withdrawals block
+	// 	WithdrawalsPerBlock:   16,
+	// 	TimeIncrements:        5,
+	// },
 
-	// 	&WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1",
-	// 			About: `
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Withdrawals Fork on Block 1",
+	// 		About: `
 	// 			Tests the withdrawals fork happening directly after genesis.
 	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Only Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 1,
-	// 		WithdrawalsPerBlock:   16,
 	// 	},
+	// 	WithdrawalsForkHeight: 1, // Only Genesis is Pre-Withdrawals
+	// 	WithdrawalsBlockCount: 1,
+	// 	WithdrawalsPerBlock:   16,
+	// },
 
-	// 	&WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 5",
-	// 			About: `
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Withdrawals Fork on Block 5",
+	// 		About: `
 	// 			Tests the transition to the withdrawals fork after a single block
 	// 			has happened.
 	// 			Block 1 is sent with invalid non-null withdrawals payload and
 	// 			client is expected to respond with the appropriate error.
 	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight: 5, // Genesis and Block 1 are Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 1,
-	// 		WithdrawalsPerBlock:   16,
-	// 		TimeIncrements:        5,
 	// 	},
+	// 	WithdrawalsForkHeight: 5, // Genesis and Block 1 are Pre-Withdrawals
+	// 	WithdrawalsBlockCount: 1,
+	// 	WithdrawalsPerBlock:   16,
+	// 	TimeIncrements:        5,
+	// },
 
 	// &WithdrawalsBaseSpec{
 	// 	Spec: test.Spec{
@@ -149,91 +149,92 @@ var Tests = []test.SpecInterface{
 	// 	TestCorrupedHashPayloads: true,
 	// },
 
-	// 	&WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdraw to a single account",
-	// 			About: `
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Withdraw to a single account",
+	// 		About: `
 	// 			Make multiple withdrawals to a single account.
 	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight:    1,
-	// 		WithdrawalsBlockCount:    1,
-	// 		WithdrawalsPerBlock:      64,
-	// 		WithdrawableAccountCount: 1,
 	// 	},
+	// 	WithdrawalsForkHeight:    1,
+	// 	WithdrawalsBlockCount:    1,
+	// 	WithdrawalsPerBlock:      64,
+	// 	WithdrawableAccountCount: 1,
+	// },
 
-	// 	&WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdraw to two accounts",
-	// 			About: `
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Withdraw to two accounts",
+	// 		About: `
 	// 			Make multiple withdrawals to two different accounts, repeated in
 	// 			round-robin.
 	// 			Reasoning: There might be a difference in implementation when an
 	// 			account appears multiple times in the withdrawals list but the list
 	// 			is not in ordered sequence.
 	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight:    1,
-	// 		WithdrawalsBlockCount:    1,
-	// 		WithdrawalsPerBlock:      64,
-	// 		WithdrawableAccountCount: 2,
 	// 	},
+	// 	WithdrawalsForkHeight:    1,
+	// 	WithdrawalsBlockCount:    1,
+	// 	WithdrawalsPerBlock:      64,
+	// 	WithdrawableAccountCount: 2,
+	// },
 
-	// 	&WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdraw many accounts",
-	// 			About: `
-	// 			Make multiple withdrawals to 1024 different accounts.
-	// 			Execute many blocks this way.
-	// 			`,
-	// 			TimeoutSeconds: 240,
-	// 		},
-	// 		WithdrawalsForkHeight:    1,
-	// 		WithdrawalsBlockCount:    4,
-	// 		WithdrawalsPerBlock:      1024,
-	// 		WithdrawableAccountCount: 1024,
-	// 	},
+	// TODO: panicing with new timestamp increment scheme
+	&WithdrawalsBaseSpec{
+		Spec: test.Spec{
+			Name: "Withdraw many accounts",
+			About: `
+				Make multiple withdrawals to 1024 different accounts.
+				Execute many blocks this way.
+				`,
+			TimeoutSeconds: 3600,
+		},
+		WithdrawalsForkHeight:    1,
+		WithdrawalsBlockCount:    4,
+		WithdrawalsPerBlock:      1024,
+		WithdrawableAccountCount: 1024,
+	},
 
-	// 	&WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdraw zero amount",
-	// 			About: `
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Withdraw zero amount",
+	// 		About: `
 	// 			Make multiple withdrawals where the amount withdrawn is 0.
 	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight:    1,
-	// 		WithdrawalsBlockCount:    1,
-	// 		WithdrawalsPerBlock:      64,
-	// 		WithdrawableAccountCount: 2,
-	// 		WithdrawAmounts: []uint64{
-	// 			0,
-	// 			1,
-	// 		},
 	// 	},
+	// 	WithdrawalsForkHeight:    1,
+	// 	WithdrawalsBlockCount:    1,
+	// 	WithdrawalsPerBlock:      64,
+	// 	WithdrawableAccountCount: 2,
+	// 	WithdrawAmounts: []uint64{
+	// 		0,
+	// 		1,
+	// 	},
+	// },
 
-	// 	&WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Empty Withdrawals",
-	// 			About: `
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Empty Withdrawals",
+	// 		About: `
 	// 			Produce withdrawals block with zero withdrawals.
 	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight: 1,
-	// 		WithdrawalsBlockCount: 1,
-	// 		WithdrawalsPerBlock:   0,
 	// 	},
+	// 	WithdrawalsForkHeight: 1,
+	// 	WithdrawalsBlockCount: 1,
+	// 	WithdrawalsPerBlock:   0,
+	// },
 
-	// 	&WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Corrupted Block Hash Payload (INVALID)",
-	// 			About: `
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Corrupted Block Hash Payload (INVALID)",
+	// 		About: `
 	// 			Send a valid payload with a corrupted hash using engine_newPayloadV2.
 	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight:    1,
-	// 		WithdrawalsBlockCount:    1,
-	// 		TestCorrupedHashPayloads: true,
 	// 	},
+	// 	WithdrawalsForkHeight:    1,
+	// 	WithdrawalsBlockCount:    1,
+	// 	TestCorrupedHashPayloads: true,
+	// },
 
 	//Block value tests
 	//&BlockValueSpec{
@@ -376,217 +377,213 @@ var Tests = []test.SpecInterface{
 	},
 
 	// //Re-Org tests
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
-				About: `
-				Tests a simple 1 block re-org
-				`,
-				SlotsToSafe:      big.NewInt(16),
-				SlotsToFinalized: big.NewInt(32),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 3,
-			WithdrawalsPerBlock:   16,
-		},
-		ReOrgBlockCount: 1,
-		ReOrgViaSync:    false,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
+	// 			About: `
+	// 			Tests a simple 1 block re-org
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 3,
+	// 		WithdrawalsPerBlock:   16,
+	// 	},
+	// 	ReOrgBlockCount: 1,
+	// 	ReOrgViaSync:    false,
+	// },
 
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
-				About: `
-				Tests a simple 1 block re-org
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 16,
-			WithdrawalsPerBlock:   16,
-		},
-		ReOrgBlockCount: 1,
-		ReOrgViaSync:    false,
-	},
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
-				About: `
-				Tests a 8 block re-org using NewPayload
-				Re-org does not change withdrawals fork height
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 16,
-			WithdrawalsPerBlock:   16,
-		},
-		ReOrgBlockCount: 8,
-		ReOrgViaSync:    false,
-	},
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
-				About: `
-				Tests a 8 block re-org using NewPayload
-				Re-org does not change withdrawals fork height
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 16,
-			WithdrawalsPerBlock:   16,
-		},
-		ReOrgBlockCount: 8,
-		ReOrgViaSync:    true,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 1 Block Re-Org",
+	// 			About: `
+	// 			Tests a simple 1 block re-org
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 16,
+	// 		WithdrawalsPerBlock:   16,
+	// 	},
+	// 	ReOrgBlockCount: 1,
+	// 	ReOrgViaSync:    false,
+	// },
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
+	// 			About: `
+	// 			Tests a 8 block re-org using NewPayload
+	// 			Re-org does not change withdrawals fork height
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 16,
+	// 		WithdrawalsPerBlock:   16,
+	// 	},
+	// 	ReOrgBlockCount: 8,
+	// 	ReOrgViaSync:    false,
+	// },
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
+	// 			About: `
+	// 			Tests a 8 block re-org using NewPayload
+	// 			Re-org does not change withdrawals fork height
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 16,
+	// 		WithdrawalsPerBlock:   16,
+	// 	},
+	// 	ReOrgBlockCount: 8,
+	// 	ReOrgViaSync:    true,
+	// },
 
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload",
-				About: `
-				Tests a 10 block re-org using NewPayload
-				Re-org does not change withdrawals fork height, but changes
-				the payload at the height of the fork
-				`,
-				SlotsToSafe:      big.NewInt(16),
-				SlotsToFinalized: big.NewInt(32),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-		},
-		ReOrgBlockCount: 10,
-		ReOrgViaSync:    false,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload",
+	// 			About: `
+	// 			Tests a 10 block re-org using NewPayload
+	// 			Re-org does not change withdrawals fork height, but changes
+	// 			the payload at the height of the fork
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 	},
+	// 	ReOrgBlockCount: 10,
+	// 	ReOrgViaSync:    false,
+	// },
 
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
-				About: `
-				Tests a 10 block re-org using sync
-				Re-org does not change withdrawals fork height, but changes
-				the payload at the height of the fork
-				`,
-				SlotsToSafe:      big.NewInt(16),
-				SlotsToFinalized: big.NewInt(32),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-		},
-		ReOrgBlockCount: 10,
-		ReOrgViaSync:    true,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
+	// 			About: `
+	// 			Tests a 10 block re-org using sync
+	// 			Re-org does not change withdrawals fork height, but changes
+	// 			the payload at the height of the fork
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 	},
+	// 	ReOrgBlockCount: 10,
+	// 	ReOrgViaSync:    true,
+	// },
 
-	// TODO:
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org",
-				About: `
-				Tests a 10 block re-org using NewPayload
-				Sidechain reaches withdrawals fork at a lower block height
-				than the canonical chain
-				`,
-				SlotsToSafe:      big.NewInt(16),
-				SlotsToFinalized: big.NewInt(32),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-		},
-		ReOrgBlockCount:         10,
-		ReOrgViaSync:            false,
-		SidechainTimeIncrements: 2,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org",
+	// 			About: `
+	// 			Tests a 10 block re-org using NewPayload
+	// 			Sidechain reaches withdrawals fork at a lower block height
+	// 			than the canonical chain
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 	},
+	// 	ReOrgBlockCount:         10,
+	// 	ReOrgViaSync:            false,
+	// 	SidechainTimeIncrements: 2,
+	// },
 
-	// TODO:
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org Sync",
-				About: `
-				Tests a 10 block re-org using sync
-				Sidechain reaches withdrawals fork at a lower block height
-				than the canonical chain
-				`,
-				SlotsToSafe:      big.NewInt(16),
-				SlotsToFinalized: big.NewInt(32),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-		},
-		ReOrgBlockCount:         10,
-		ReOrgViaSync:            true,
-		SidechainTimeIncrements: 2,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org Sync",
+	// 			About: `
+	// 			Tests a 10 block re-org using sync
+	// 			Sidechain reaches withdrawals fork at a lower block height
+	// 			than the canonical chain
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 	},
+	// 	ReOrgBlockCount:         10,
+	// 	ReOrgViaSync:            true,
+	// 	SidechainTimeIncrements: 2,
+	// },
 
-	// TODO:
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org",
-				About: `
-				Tests a 10 block re-org using NewPayload
-				Sidechain reaches withdrawals fork at a higher block height
-				than the canonical chain
-				`,
-				SlotsToSafe:      big.NewInt(16),
-				SlotsToFinalized: big.NewInt(32),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-			TimeIncrements:        2,
-		},
-		ReOrgBlockCount:         10,
-		ReOrgViaSync:            false,
-		SidechainTimeIncrements: 1,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org",
+	// 			About: `
+	// 			Tests a 10 block re-org using NewPayload
+	// 			Sidechain reaches withdrawals fork at a higher block height
+	// 			than the canonical chain
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 		TimeIncrements:        2,
+	// 	},
+	// 	ReOrgBlockCount:         10,
+	// 	ReOrgViaSync:            false,
+	// 	SidechainTimeIncrements: 1,
+	// },
 
-	// TODO:
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org Sync",
-				About: `
-				Tests a 10 block re-org using sync
-				Sidechain reaches withdrawals fork at a higher block height
-				than the canonical chain
-				`,
-				SlotsToSafe:      big.NewInt(16),
-				SlotsToFinalized: big.NewInt(32),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-			TimeIncrements:        2,
-		},
-		ReOrgBlockCount:         10,
-		ReOrgViaSync:            true,
-		SidechainTimeIncrements: 1,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 9 - 10 Block Re-Org Sync",
+	// 			About: `
+	// 			Tests a 10 block re-org using sync
+	// 			Sidechain reaches withdrawals fork at a higher block height
+	// 			than the canonical chain
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 		TimeIncrements:        2,
+	// 	},
+	// 	ReOrgBlockCount:         10,
+	// 	ReOrgViaSync:            true,
+	// 	SidechainTimeIncrements: 1,
+	// },
 
 	// TODO: REORG SYNC WHERE SYNCED BLOCKS HAVE WITHDRAWALS BEFORE TIME
 
@@ -1074,7 +1071,7 @@ func (ws *WithdrawalsBaseSpec) Execute(t *test.Env) {
 
 	// Wait ttd
 	t.CLMock.WaitForTTD()
-
+	ws.waitForSetup(t)
 	r := t.TestEngine.TestBlockByNumber(nil)
 	r.ExpectationDescription = `
 	Requested "latest" block expecting genesis to contain
@@ -1139,8 +1136,6 @@ func (ws *WithdrawalsBaseSpec) Execute(t *test.Env) {
 			}
 		},
 	})
-
-	ws.waitForShaghai(t)
 
 	var (
 		startAccount = ws.GetWithdrawalsStartAccount()

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -179,20 +179,20 @@ var Tests = []test.SpecInterface{
 	// 	WithdrawableAccountCount: 2,
 	// },
 
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Withdraw many accounts",
-			About: `
-				Make multiple withdrawals to 1024 different accounts.
-				Execute many blocks this way.
-				`,
-			TimeoutSeconds: 3600,
-		},
-		WithdrawalsForkHeight:    1,
-		WithdrawalsBlockCount:    4,
-		WithdrawalsPerBlock:      1024,
-		WithdrawableAccountCount: 1024,
-	},
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Withdraw many accounts",
+	// 		About: `
+	// 			Make multiple withdrawals to 1024 different accounts.
+	// 			Execute many blocks this way.
+	// 			`,
+	// 		TimeoutSeconds: 3600,
+	// 	},
+	// 	WithdrawalsForkHeight:    1,
+	// 	WithdrawalsBlockCount:    4,
+	// 	WithdrawalsPerBlock:      1024,
+	// 	WithdrawableAccountCount: 1024,
+	// },
 
 	// &WithdrawalsBaseSpec{
 	// 	Spec: test.Spec{
@@ -249,7 +249,7 @@ var Tests = []test.SpecInterface{
 	//	},
 	//},
 
-	// // Sync Tests
+	// Sync Tests
 	// &WithdrawalsSyncSpec{
 	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
 	// 		Spec: test.Spec{
@@ -310,7 +310,7 @@ var Tests = []test.SpecInterface{
 	// 	SyncSteps: 1,
 	// },
 
-	// TODO:
+	// // TODO:
 	// &WithdrawalsSyncSpec{
 	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
 	// 		Spec: test.Spec{
@@ -332,7 +332,7 @@ var Tests = []test.SpecInterface{
 	// 	SyncSteps: 1,
 	// },
 
-	// TODO:
+	// // TODO:
 	// &WithdrawalsSyncSpec{
 	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
 	// 		Spec: test.Spec{
@@ -599,145 +599,145 @@ var Tests = []test.SpecInterface{
 	// 	OverflowMaxInitcodeTxCountAfterFork:  1,
 	// },
 
-	//// Execution layer withdrawals spec
-	// &WithdrawalsExecutionLayerSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 1 blocks withdrawals - 1 mass-claim",
-	// 			About: `
-	// 			- Shapella on block 1
-	// 			- 1 block with withdrawals
-	// 			- Claim accumulated withdrawals
-	// 			- Compares balances and events values with withdrawals from CL
-	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis and Block 1 are Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 1,
-	// 		WithdrawalsPerBlock:   16,
-	// 		TimeIncrements:        5,
-	// 	},
-	// 	ClaimBlocksCount: 1,
-	// },
-	// &WithdrawalsExecutionLayerSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 2 blocks withdrawals - 2 mass-claims",
-	// 			About: `
-	// 			- Shapella on block 1
-	// 			- 2 blocks with withdrawals
-	// 			- Claim accumulated withdrawals
-	// 			- Produce 1 additional pair (A, B) of blocks:
-	// 			A: block with withdrawals
-	// 			B: block with claim Tx
-	// 			- Compares balances and events values with withdrawals from CL
-	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight: 1, // Genesis and Block 1 are Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 2,
-	// 		WithdrawalsPerBlock:   16,
-	// 		TimeIncrements:        5,
-	// 	},
-	// 	ClaimBlocksCount: 2,
-	// },
-	// &WithdrawalsExecutionLayerSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 2 - 2 blocks withdrawals - 2 mass-claims",
-	// 			About: `
-	// 			- Shapella on block 2
-	// 			- 2 blocks with withdrawals
-	// 			- Claim accumulated withdrawals
-	// 			- Produce 1 additional pair (A, B) of blocks:
-	// 			A: block with withdrawals
-	// 			B: block with claim Tx
-	// 			- Compares balances and events values with withdrawals from CL
-	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight: 2,
-	// 		WithdrawalsBlockCount: 2,
-	// 		WithdrawalsPerBlock:   16,
-	// 		TimeIncrements:        5,
-	// 	},
-	// 	ClaimBlocksCount: 2,
-	// },
-	//&WithdrawalsExecutionLayerSpec{
-	//	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	//		Spec: test.Spec{
-	//			Name: "Withdrawals Fork on Block 4 - 4 blocks withdrawals - 5 mass-claims - 64 withdrawals per block",
-	//			About: `
-	//			- Shapella on block 4
-	//			- 4 blocks with withdrawals
-	//			- Claim accumulated withdrawals
-	//			- Produce 4 additional pairs (A, B) of blocks:
-	//			  A: block with withdrawals
-	//			  B: block with claim Tx
-	//			- Compares balances and events values with withdrawals from CL
-	//			`,
-	//		},
-	//		WithdrawalsForkHeight: 4,
-	//		WithdrawalsBlockCount: 4,
-	//		WithdrawalsPerBlock:   64,
-	//		TimeIncrements:        5,
-	//	},
-	//	ClaimBlocksCount: 5,
-	//},
+	// Execution layer withdrawals spec
+	&WithdrawalsExecutionLayerSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 1 blocks withdrawals - 1 mass-claim",
+				About: `
+				- Shapella on block 1
+				- 1 block with withdrawals
+				- Claim accumulated withdrawals
+				- Compares balances and events values with withdrawals from CL
+				`,
+			},
+			WithdrawalsForkHeight: 1, // Genesis and Block 1 are Pre-Withdrawals
+			WithdrawalsBlockCount: 1,
+			WithdrawalsPerBlock:   16,
+			TimeIncrements:        5,
+		},
+		ClaimBlocksCount: 1,
+	},
+	&WithdrawalsExecutionLayerSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 2 blocks withdrawals - 2 mass-claims",
+				About: `
+				- Shapella on block 1
+				- 2 blocks with withdrawals
+				- Claim accumulated withdrawals
+				- Produce 1 additional pair (A, B) of blocks:
+				A: block with withdrawals
+				B: block with claim Tx
+				- Compares balances and events values with withdrawals from CL
+				`,
+			},
+			WithdrawalsForkHeight: 1, // Genesis and Block 1 are Pre-Withdrawals
+			WithdrawalsBlockCount: 2,
+			WithdrawalsPerBlock:   16,
+			TimeIncrements:        5,
+		},
+		ClaimBlocksCount: 2,
+	},
+	&WithdrawalsExecutionLayerSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 2 - 2 blocks withdrawals - 2 mass-claims",
+				About: `
+				- Shapella on block 2
+				- 2 blocks with withdrawals
+				- Claim accumulated withdrawals
+				- Produce 1 additional pair (A, B) of blocks:
+				A: block with withdrawals
+				B: block with claim Tx
+				- Compares balances and events values with withdrawals from CL
+				`,
+			},
+			WithdrawalsForkHeight: 2,
+			WithdrawalsBlockCount: 2,
+			WithdrawalsPerBlock:   16,
+			TimeIncrements:        5,
+		},
+		ClaimBlocksCount: 2,
+	},
+	&WithdrawalsExecutionLayerSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 4 - 4 blocks withdrawals - 5 mass-claims - 64 withdrawals per block",
+				About: `
+				- Shapella on block 4
+				- 4 blocks with withdrawals
+				- Claim accumulated withdrawals
+				- Produce 4 additional pairs (A, B) of blocks:
+				  A: block with withdrawals
+				  B: block with claim Tx
+				- Compares balances and events values with withdrawals from CL
+				`,
+			},
+			WithdrawalsForkHeight: 4,
+			WithdrawalsBlockCount: 4,
+			WithdrawalsPerBlock:   64,
+			TimeIncrements:        5,
+		},
+		ClaimBlocksCount: 5,
+	},
 
-	// &WithdrawalsExecutionLayerSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 5",
-	// 			About: `
-	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight: 5,
-	// 		WithdrawalsBlockCount: 1,
-	// 		WithdrawalsPerBlock:   32,
-	// 		TimeIncrements:        5,
-	// 	},
-	// 	ClaimBlocksCount: 2,
-	// },
-	// &WithdrawalsExecutionLayerSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 2 - 8 blocks withdrawals - 2 mass-claims - 256 withdrawals per block",
-	// 			About: `
-	// 			- Shapella on block 2
-	// 			- 8 blocks with withdrawals
-	// 			- Claim accumulated withdrawals
-	// 			- Produce 1 additional pair (A, B) of blocks:
-	// 			A: block with withdrawals
-	// 			B: block with claim Tx
-	// 			- Compares balances and events values with withdrawals from CL
-	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight: 2,
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   256,
-	// 		TimeIncrements:        5,
-	// 	},
-	// 	ClaimBlocksCount: 2,
-	// },
-	// &WithdrawalsExecutionLayerSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Block 1 - 3 blocks withdrawals - 4 mass-claims - 1024 withdrawals per block",
-	// 			About: `
-	// 			- Shapella on block 1
-	// 			- 3 blocks with withdrawals
-	// 			- Claim accumulated withdrawals
-	// 			- Produce 3 additional pairs (A, B) of blocks:
-	// 			A: block with withdrawals
-	// 			B: block with claim Tx
-	// 			- Compares balances and events values with withdrawals from CL
-	// 			`,
-	// 		},
-	// 		WithdrawalsForkHeight: 1,
-	// 		WithdrawalsBlockCount: 3,
-	// 		WithdrawalsPerBlock:   1024,
-	// 		TimeIncrements:        5,
-	// 	},
-	// 	ClaimBlocksCount: 4,
-	// },
+	&WithdrawalsExecutionLayerSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 5",
+				About: `
+				`,
+			},
+			WithdrawalsForkHeight: 5,
+			WithdrawalsBlockCount: 1,
+			WithdrawalsPerBlock:   32,
+			TimeIncrements:        5,
+		},
+		ClaimBlocksCount: 2,
+	},
+	&WithdrawalsExecutionLayerSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 2 - 8 blocks withdrawals - 2 mass-claims - 256 withdrawals per block",
+				About: `
+				- Shapella on block 2
+				- 8 blocks with withdrawals
+				- Claim accumulated withdrawals
+				- Produce 1 additional pair (A, B) of blocks:
+				A: block with withdrawals
+				B: block with claim Tx
+				- Compares balances and events values with withdrawals from CL
+				`,
+			},
+			WithdrawalsForkHeight: 2,
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   256,
+			TimeIncrements:        5,
+		},
+		ClaimBlocksCount: 2,
+	},
+	&WithdrawalsExecutionLayerSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Block 1 - 3 blocks withdrawals - 4 mass-claims - 1024 withdrawals per block",
+				About: `
+				- Shapella on block 1
+				- 3 blocks with withdrawals
+				- Claim accumulated withdrawals
+				- Produce 3 additional pairs (A, B) of blocks:
+				A: block with withdrawals
+				B: block with claim Tx
+				- Compares balances and events values with withdrawals from CL
+				`,
+			},
+			WithdrawalsForkHeight: 1,
+			WithdrawalsBlockCount: 3,
+			WithdrawalsPerBlock:   1024,
+			TimeIncrements:        5,
+		},
+		ClaimBlocksCount: 4,
+	},
 }
 
 // Helper types to convert gwei into wei more easily
@@ -1845,7 +1845,7 @@ func (ws *WithdrawalsExecutionLayerSpec) Execute(t *test.Env) {
 	withdrawalRoot=nil, because genesis.timestamp < shanghaiTime
 	`
 	r.ExpectWithdrawalsRoot(nil)
-
+	ws.waitForSetup(t)
 	// Produce any blocks necessary to reach withdrawals fork
 	t.CLMock.ProduceBlocks(int(ws.GetPreWithdrawalsBlockCount()), clmock.BlockProcessCallbacks{
 		OnPayloadProducerSelected: func() {
@@ -1866,8 +1866,6 @@ func (ws *WithdrawalsExecutionLayerSpec) Execute(t *test.Env) {
 			}
 		},
 	})
-
-	ws.waitForShanghai(t)
 
 	var (
 		startAccount = ws.GetWithdrawalsStartAccount()

--- a/simulators/ethereum/engine/suites/withdrawals/tests.go
+++ b/simulators/ethereum/engine/suites/withdrawals/tests.go
@@ -133,22 +133,22 @@ var Tests = []test.SpecInterface{
 	// 		TimeIncrements:        5,
 	// 	},
 
-	&WithdrawalsBaseSpec{
-		Spec: test.Spec{
-			Name: "Withdrawals Fork on Block 3",
-			About: `
-			Tests the transition to the withdrawals fork after two blocks
-			have happened.
-			Block 2 is sent with invalid non-null withdrawals payload and
-			client is expected to respond with the appropriate error.
-			`,
-		},
-		WithdrawalsForkHeight:    3, // Genesis, Block 1 and 2 are Pre-Withdrawals
-		WithdrawalsBlockCount:    1,
-		WithdrawalsPerBlock:      16,
-		TimeIncrements:           5,
-		TestCorrupedHashPayloads: true,
-	},
+	// &WithdrawalsBaseSpec{
+	// 	Spec: test.Spec{
+	// 		Name: "Withdrawals Fork on Block 3",
+	// 		About: `
+	// 		Tests the transition to the withdrawals fork after two blocks
+	// 		have happened.
+	// 		Block 2 is sent with invalid non-null withdrawals payload and
+	// 		client is expected to respond with the appropriate error.
+	// 		`,
+	// 	},
+	// 	WithdrawalsForkHeight:    3, // Genesis, Block 1 and 2 are Pre-Withdrawals
+	// 	WithdrawalsBlockCount:    1,
+	// 	WithdrawalsPerBlock:      16,
+	// 	TimeIncrements:           5,
+	// 	TestCorrupedHashPayloads: true,
+	// },
 
 	// 	&WithdrawalsBaseSpec{
 	// 		Spec: test.Spec{
@@ -376,7 +376,7 @@ var Tests = []test.SpecInterface{
 		SyncSteps: 1,
 	},
 
-	//Re-Org tests
+	// //Re-Org tests
 	&WithdrawalsReorgSpec{
 		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
 			Spec: test.Spec{
@@ -395,86 +395,86 @@ var Tests = []test.SpecInterface{
 		ReOrgBlockCount: 1,
 		ReOrgViaSync:    false,
 	},
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
-				About: `
-				Tests a 8 block re-org using NewPayload
-				Re-org does not change withdrawals fork height
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
-			},
-			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 16,
-			WithdrawalsPerBlock:   16,
-		},
-		ReOrgBlockCount: 8,
-		ReOrgViaSync:    false,
-	},
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
-				About: `
-				Tests a 8 block re-org using NewPayload
-				Re-org does not change withdrawals fork height
-				`,
-				SlotsToSafe:      big.NewInt(32),
-				SlotsToFinalized: big.NewInt(64),
-				TimeoutSeconds:   300,
-			},
-			WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 16,
-			WithdrawalsPerBlock:   16,
-		},
-		ReOrgBlockCount: 8,
-		ReOrgViaSync:    true,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org NewPayload",
+	// 			About: `
+	// 			Tests a 8 block re-org using NewPayload
+	// 			Re-org does not change withdrawals fork height
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   300,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 16,
+	// 		WithdrawalsPerBlock:   16,
+	// 	},
+	// 	ReOrgBlockCount: 8,
+	// 	ReOrgViaSync:    false,
+	// },
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 1 - 8 Block Re-Org, Sync",
+	// 			About: `
+	// 			Tests a 8 block re-org using NewPayload
+	// 			Re-org does not change withdrawals fork height
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(32),
+	// 			SlotsToFinalized: big.NewInt(64),
+	// 			TimeoutSeconds:   300,
+	// 		},
+	// 		WithdrawalsForkHeight: 1, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 16,
+	// 		WithdrawalsPerBlock:   16,
+	// 	},
+	// 	ReOrgBlockCount: 8,
+	// 	ReOrgViaSync:    true,
+	// },
 
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload",
-				About: `
-				Tests a 10 block re-org using NewPayload
-				Re-org does not change withdrawals fork height, but changes
-				the payload at the height of the fork
-				`,
-				SlotsToSafe:      big.NewInt(16),
-				SlotsToFinalized: big.NewInt(32),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-		},
-		ReOrgBlockCount: 10,
-		ReOrgViaSync:    false,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org NewPayload",
+	// 			About: `
+	// 			Tests a 10 block re-org using NewPayload
+	// 			Re-org does not change withdrawals fork height, but changes
+	// 			the payload at the height of the fork
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 	},
+	// 	ReOrgBlockCount: 10,
+	// 	ReOrgViaSync:    false,
+	// },
 
-	&WithdrawalsReorgSpec{
-		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-			Spec: test.Spec{
-				Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
-				About: `
-				Tests a 10 block re-org using sync
-				Re-org does not change withdrawals fork height, but changes
-				the payload at the height of the fork
-				`,
-				SlotsToSafe:      big.NewInt(16),
-				SlotsToFinalized: big.NewInt(32),
-				TimeoutSeconds:   3600,
-			},
-			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-			WithdrawalsBlockCount: 8,
-			WithdrawalsPerBlock:   128,
-		},
-		ReOrgBlockCount: 10,
-		ReOrgViaSync:    true,
-	},
+	// &WithdrawalsReorgSpec{
+	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+	// 		Spec: test.Spec{
+	// 			Name: "Withdrawals Fork on Block 8 - 10 Block Re-Org Sync",
+	// 			About: `
+	// 			Tests a 10 block re-org using sync
+	// 			Re-org does not change withdrawals fork height, but changes
+	// 			the payload at the height of the fork
+	// 			`,
+	// 			SlotsToSafe:      big.NewInt(16),
+	// 			SlotsToFinalized: big.NewInt(32),
+	// 			TimeoutSeconds:   3600,
+	// 		},
+	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+	// 		WithdrawalsBlockCount: 8,
+	// 		WithdrawalsPerBlock:   128,
+	// 	},
+	// 	ReOrgBlockCount: 10,
+	// 	ReOrgViaSync:    true,
+	// },
 
 	// // TODO:
 	// &WithdrawalsReorgSpec{
@@ -500,27 +500,27 @@ var Tests = []test.SpecInterface{
 	// },
 
 	// // TODO:
-	// &WithdrawalsReorgSpec{
-	// 	WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
-	// 		Spec: test.Spec{
-	// 			Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org Sync",
-	// 			About: `
-	// 			Tests a 10 block re-org using sync
-	// 			Sidechain reaches withdrawals fork at a lower block height
-	// 			than the canonical chain
-	// 			`,
-	// 			SlotsToSafe:      big.NewInt(16),
-	// 			SlotsToFinalized: big.NewInt(32),
-	// 			TimeoutSeconds:   3600,
-	// 		},
-	// 		WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
-	// 		WithdrawalsBlockCount: 8,
-	// 		WithdrawalsPerBlock:   128,
-	// 	},
-	// 	ReOrgBlockCount:         10,
-	// 	ReOrgViaSync:            true,
-	// 	SidechainTimeIncrements: 2,
-	// },
+	&WithdrawalsReorgSpec{
+		WithdrawalsBaseSpec: &WithdrawalsBaseSpec{
+			Spec: test.Spec{
+				Name: "Withdrawals Fork on Canonical Block 8 / Side Block 7 - 10 Block Re-Org Sync",
+				About: `
+				Tests a 10 block re-org using sync
+				Sidechain reaches withdrawals fork at a lower block height
+				than the canonical chain
+				`,
+				SlotsToSafe:      big.NewInt(16),
+				SlotsToFinalized: big.NewInt(32),
+				TimeoutSeconds:   3600,
+			},
+			WithdrawalsForkHeight: 8, // Genesis is Pre-Withdrawals
+			WithdrawalsBlockCount: 8,
+			WithdrawalsPerBlock:   128,
+		},
+		ReOrgBlockCount:         10,
+		ReOrgViaSync:            true,
+		SidechainTimeIncrements: 2,
+	},
 
 	// // TODO:
 	// &WithdrawalsReorgSpec{
@@ -1346,9 +1346,6 @@ func (ws *WithdrawalsSyncSpec) Execute(t *test.Env) {
 
 	t.CLMock.LatestForkchoice.HeadBlockHash = block1.Hash()
 
-	//Spawn a secondary client which will need to sync to the primary client
-	t.CLMock.AddEngineClient(secondaryEngine)
-
 	if ws.SyncSteps > 1 {
 		// TODO
 	} else {
@@ -1446,7 +1443,7 @@ func (ws *WithdrawalsReorgSpec) Execute(t *test.Env) {
 	t.CLMock.ShanghaiTimestamp = big.NewInt(0).SetUint64(shangaiTime)
 
 	t.CLMock.WaitForTTD()
-	t.Genesis.Config().ShanghaiTime = &shangaiTime
+
 	// Spawn a secondary client which will produce the sidechain
 	secondaryEngine, err := hive_rpc.HiveRPCEngineStarter{}.StartClient(t.T, t.TestContext, t.Genesis, t.ClientParams, t.ClientFiles, t.Engine)
 	if err != nil {
@@ -1570,6 +1567,10 @@ func (ws *WithdrawalsReorgSpec) Execute(t *test.Env) {
 					version int
 					payload *beacon.ExecutableData
 				)
+				isShanghai := shangaiTime <= uint64(time.Now().Unix())
+				_ = isShanghai
+				withdrawalsForkHeight := ws.GetSidechainWithdrawalsForkHeight()
+				_ = withdrawalsForkHeight
 				if t.CLMock.CurrentPayloadNumber >= ws.GetSidechainWithdrawalsForkHeight() {
 					version = 2
 				} else {

--- a/simulators/ethereum/engine/test/expect.go
+++ b/simulators/ethereum/engine/test/expect.go
@@ -880,6 +880,20 @@ func (tec *TestEngineClient) TestBalanceAt(account common.Address, number *big.I
 	if err, ok := err.(rpc.Error); ok {
 		ret.ErrorCode = err.ErrorCode()
 	}
+	if err != nil {
+		return ret
+	}
+	if number == nil {
+		n, err := tec.Engine.BlockNumber(ctx)
+		if err != nil {
+			ret.Error = err
+			if err, ok := err.(rpc.Error); ok {
+				ret.ErrorCode = err.ErrorCode()
+			}
+			return ret
+		}
+		ret.Block = big.NewInt(int64(n))
+	}
 	return ret
 }
 
@@ -890,7 +904,7 @@ func (exp *BalanceResponseExpectObject) ExpectNoError() {
 }
 
 func (exp *BalanceResponseExpectObject) ExpectBalanceEqual(expBalance *big.Int) {
-	exp.Logf("INFO (%s): Testing balance for account %s on block %d: actual=%d, expected=%d",
+	exp.Logf("INFO (%s): Testing balance for account %s on block %s: actual=%d, expected=%d",
 		exp.TestName,
 		exp.Account,
 		exp.Block,

--- a/simulators/ethereum/engine/test/spec.go
+++ b/simulators/ethereum/engine/test/spec.go
@@ -33,6 +33,7 @@ type SpecInterface interface {
 	GetTimeout() int
 	GetTTD() int64
 	GetPreShapellaBlockCount() int
+	GetBlockTimeIncrements() uint64
 	IsMiningDisabled() bool
 }
 
@@ -164,5 +165,9 @@ func (s Spec) IsMiningDisabled() bool {
 }
 
 func (s Spec) GetPreShapellaBlockCount() int {
+	return 0
+}
+
+func (s Spec) GetBlockTimeIncrements() uint64 {
 	return 0
 }


### PR DESCRIPTION
This PR introduce fixes for re-org spec and couple other tests. 

To fix re-org spec new payload timestamps calculation was introduced:
Now instead waiting for shanghai timestamp in far future simulator waits for `SetupTime` (now 3 min) to make sure environments is prepared for test execution and all clients started.
- Now shanghai timestamp calculated as follows:
`ShanghaiTimestamp == SetupTime + (pre-shanghai blocks count * block time)`
- End of setup timestamp also can be retrieved from `ShanghaiTimestamp` as follows:
`SetupTimestamp == ShanghaiTimestamp - (pre-shanghai blocks count * block time)`

All new blocks timestamps increment identically and shapella happens just in time all pre-shapella blocks executed.

Current state:
- [x] Base spec
- [ ] Sync spec (some tests still doesnt work but problem is not related to payload timestamps
- [x] Re-org spec
- [x] Execution layer spec
