### PR TITLE
Fixed nethermind withdawals tests

### DIFF
--- a/simulators/ethereum/engine/globals/globals.go
+++ b/simulators/ethereum/engine/globals/globals.go
@@ -2,6 +2,8 @@ package globals
 
 import (
 	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/binary"
 	"math/big"
 	"time"
 
@@ -114,16 +116,14 @@ var (
 func init() {
 	// Fill the test accounts with deterministic addresses
 	TestAccounts = make([]*TestAccount, TestAccountCount)
-	TestAccounts[0] = NewTestAccount(GnoVaultVaultKey, &GnoVaultAccountAddress, 0)
-	TestAccounts[1] = NewTestAccount(VaultKey, &VaultAccountAddress, 0)
-	//for i := uint64(0); i < TestAccountCount; i++ {
-	//	bs := make([]byte, 8)
-	//	binary.BigEndian.PutUint64(bs, uint64(i))
-	//	b := sha256.Sum256(bs)
-	//	k, err := crypto.ToECDSA(b[:])
-	//	if err != nil {
-	//		panic(err)
-	//	}
-	//	TestAccounts[i] = &TestAccount{key: k, index: i}
-	//}
+	for i := uint64(0); i < TestAccountCount; i++ {
+		bs := make([]byte, 8)
+		binary.BigEndian.PutUint64(bs, uint64(i))
+		b := sha256.Sum256(bs)
+		k, err := crypto.ToECDSA(b[:])
+		if err != nil {
+			panic(err)
+		}
+		TestAccounts[i] = &TestAccount{key: k, index: i}
+	}
 }


### PR DESCRIPTION
Fixed `panic: runtime error: invalid memory address or nil pointer dereference` error that fail some tests.
Run all the withdrawals tests [locally](https://share.cleanshot.com/QNlfgclq).  With the fix the tests from [engine-withdrawals](https://hive-gno.nethermind.io/suite.html?suiteid=1719540069-9ba1ad75a8f2de7a5c0fc97e7e02346b.json&suitename=engine-withdrawals#) suite should be passed.  

