### PR TITLE
Erigon and Nethermind tests small improvements

### DIFF
--- a/simulators/ethereum/engine-gnosis-erigon/main.go
+++ b/simulators/ethereum/engine-gnosis-erigon/main.go
@@ -13,9 +13,9 @@ import (
 	"github.com/ethereum/hive/simulators/ethereum/engine/helper"
 	"github.com/ethereum/hive/simulators/ethereum/engine/test"
 
-	//suite_auth "github.com/ethereum/hive/simulators/ethereum/engine/suites/auth"
+	suite_auth "github.com/ethereum/hive/simulators/ethereum/engine/suites/auth"
 	//suite_engine "github.com/ethereum/hive/simulators/ethereum/engine/suites/engine"
-	//suite_ex_cap "github.com/ethereum/hive/simulators/ethereum/engine/suites/exchange_capabilities"
+	suite_ex_cap "github.com/ethereum/hive/simulators/ethereum/engine/suites/exchange_capabilities"
 	//suite_transition "github.com/ethereum/hive/simulators/ethereum/engine/suites/transition"
 	suite_cancun "github.com/ethereum/hive/simulators/ethereum/engine/suites/cancun"
 	suite_withdrawals "github.com/ethereum/hive/simulators/ethereum/engine/suites/withdrawals"
@@ -39,21 +39,21 @@ func main() {
 		//Test Engine API tests using CL mocker to inject commands into clients and drive
 		//them through the merge.`[1:],
 		//	}
-		//	auth = hivesim.Suite{
-		//		Name: "engine-auth",
-		//		Description: `
-		//Test Engine API authentication features.`[1:],
-		//	}
-		//	excap = hivesim.Suite{
-		//		Name: "engine-exchange-capabilities",
-		//		Description: `
-		//Test Engine API exchange capabilities.`[1:],
-		//	}
-		//	sync = hivesim.Suite{
-		//		Name: "engine-sync",
-		//		Description: `
-		//Test Engine API sync, pre/post merge.`[1:],
-		//	}
+		auth = hivesim.Suite{
+			Name: "engine-auth",
+			Description: `
+		Test Engine API authentication features.`[1:],
+		}
+		excap = hivesim.Suite{
+			Name: "engine-exchange-capabilities",
+			Description: `
+		Test Engine API exchange capabilities.`[1:],
+		}
+		// sync = hivesim.Suite{
+		// 	Name: "engine-sync",
+		// 	Description: `
+		// Test Engine API sync, pre/post merge.`[1:],
+		// }
 		withdrawals = hivesim.Suite{
 			Name: "engine-withdrawals",
 			Description: `
@@ -69,8 +69,8 @@ func main() {
 
 	//addTestsToSuite(simulator, &engine, specToInterface(suite_engine.Tests), "full")
 	//addTestsToSuite(simulator, &transition, specToInterface(suite_transition.Tests), "full")
-	//addTestsToSuite(simulator, &auth, specToInterface(suite_auth.Tests), "full")
-	//addTestsToSuite(simulator, &excap, specToInterface(suite_ex_cap.Tests), "full")
+	addTestsToSuite(simulator, &auth, suite_auth.Tests, "full")
+	addTestsToSuite(simulator, &excap, suite_ex_cap.Tests, "full")
 	//suite_sync.AddSyncTestsToSuite(simulator, &sync, suite_sync.Tests)
 	addTestsToSuite(simulator, &withdrawals, suite_withdrawals.Tests, "full")
 	addTestsToSuite(simulator, &cancun, suite_cancun.Tests, "full")

--- a/simulators/ethereum/gnosis-engine-jq/suites/withdrawals/tests.go
+++ b/simulators/ethereum/gnosis-engine-jq/suites/withdrawals/tests.go
@@ -6,9 +6,10 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core"
 	"math/big"
 	"time"
+
+	"github.com/ethereum/go-ethereum/core"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	beacon "github.com/ethereum/go-ethereum/beacon/engine"
@@ -111,7 +112,7 @@ var Tests = []test.Spec{
 
 	&WithdrawalsBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "Withdrawals Fork on Block 1",
+			Name: "Gnosis Withdrawals Fork on Block 1",
 			About: `
 				Tests the withdrawals fork happening directly after genesis.
 				`,
@@ -695,6 +696,7 @@ var Tests = []test.Spec{
 				B: block with claim Tx
 				- Compares balances and events values with withdrawals from CL
 				`,
+				TimeoutSeconds: 1800,
 			},
 			WithdrawalsForkHeight: 2,
 			WithdrawalsBlockCount: 8,

--- a/simulators/ethereum/gnosis-engine-jq/suites/withdrawals/tests.go
+++ b/simulators/ethereum/gnosis-engine-jq/suites/withdrawals/tests.go
@@ -112,7 +112,7 @@ var Tests = []test.Spec{
 
 	&WithdrawalsBaseSpec{
 		BaseSpec: test.BaseSpec{
-			Name: "Gnosis Withdrawals Fork on Block 1",
+			Name: "Withdrawals Fork on Block 1",
 			About: `
 				Tests the withdrawals fork happening directly after genesis.
 				`,


### PR DESCRIPTION
1. Enabled engine-auth and engine-exchange-capabilities for erigon (old simulator)
2. Increased default timeout for "Withdrawals Fork on Block 2 - 8 blocks withdrawals - 2 mass-claims - 256 withdrawals per block" test

Merge to reflow branch