### PR TITLE
Reflow: Enable Engine api tests

### DIFF
--- a/simulators/ethereum/gnosis-engine-jq/client/hive_rpc/hive_rpc.go
+++ b/simulators/ethereum/gnosis-engine-jq/client/hive_rpc/hive_rpc.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core"
 	"math/big"
 	"net"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum/core"
 
 	api "github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
@@ -343,19 +344,15 @@ func (ec *HiveRPCEngineClient) HeaderByNumber(ctx context.Context, number *big.I
 
 	url, _ := ec.Url()
 	var requestBody string
-	if number == nil {
+	var blockNum = toBlockNumArg(number)
 
-		requestBody = fmt.Sprintf(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["%v",true],"id":1}`, "latest")
-	} else {
+	requestBody = fmt.Sprintf(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["%v",true],"id":1}`, blockNum)
 
-		requestBody = fmt.Sprintf(`{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["%v",true],"id":1}`, number.Int64())
-	}
-
-	blockHash, err := getBlockHash(url, requestBody)
+	byNumber, err := ec.Client.BlockByNumber(ctx, number)
 	if err != nil {
 		return nil, err
 	}
-	byNumber, err := ec.Client.BlockByNumber(ctx, number)
+	blockHash, err := getBlockHash(url, requestBody)
 	if err != nil {
 		return nil, err
 	}

--- a/simulators/ethereum/gnosis-engine-jq/main.go
+++ b/simulators/ethereum/gnosis-engine-jq/main.go
@@ -99,7 +99,7 @@ func main() {
 	simulator := hivesim.New()
 
 	// Mark suites for execution
-	//hivesim.MustRunSuite(simulator, engine)
+	hivesim.MustRunSuite(simulator, engine)
 	hivesim.MustRunSuite(simulator, auth)
 	hivesim.MustRunSuite(simulator, excap)
 	// hivesim.MustRunSuite(simulator, syncSuite)
@@ -173,6 +173,11 @@ func makeRunner(tests []test.Spec, nodeType string) func(t *hivesim.T) {
 			// Load the genesis file specified and dynamically bundle it.
 			genesis := currentTest.GetGenesis()
 			forkConfig := currentTest.GetForkConfig()
+			if forkConfig == nil {
+				// Test cannot be configured as is for current fork, skip
+				fmt.Printf("skipping test \"%s\" because fork configuration is not possible\n", currentTestName)
+				continue
+			}
 
 			cancunTimestamp := new(big.Int).Add(timestamp, big.NewInt(0))
 			shanghaiTimestamp := new(big.Int).Add(timestamp, big.NewInt(-1000000))
@@ -184,11 +189,6 @@ func makeRunner(tests []test.Spec, nodeType string) func(t *hivesim.T) {
 
 			forkConfig.ShanghaiTimestamp = shanghaiTimestamp
 
-			if forkConfig == nil {
-				// Test cannot be configured as is for current fork, skip
-				fmt.Printf("skipping test \"%s\" because fork configuration is not possible\n", currentTestName)
-				continue
-			}
 			forkConfig.ConfigGenesis(genesis)
 			genesisStartOption, err := helper.GenesisStartOption(genesis)
 			if err != nil {

--- a/simulators/ethereum/gnosis-engine-jq/suites/engine/tests.go
+++ b/simulators/ethereum/gnosis-engine-jq/suites/engine/tests.go
@@ -252,53 +252,57 @@ func init() {
 	}
 
 	// Invalid Ancestor Re-Org Tests (Reveal Via Sync)
-	spec := test.BaseSpec{
-		TimeoutSeconds:   60,
-		SlotsToSafe:      big.NewInt(32),
-		SlotsToFinalized: big.NewInt(64),
-	}
-	for _, invalidField := range []helper.InvalidPayloadBlockField{
-		helper.InvalidStateRoot,
-		helper.InvalidReceiptsRoot,
-		// TODO: helper.InvalidNumber, Test is causing a panic on the secondary node, disabling for now.
-		helper.InvalidGasLimit,
-		helper.InvalidGasUsed,
-		helper.InvalidTimestamp,
-		// TODO: helper.InvalidPrevRandao, Test consistently fails with Failed to set invalid block: missing trie node.
-		helper.RemoveTransaction,
-		helper.InvalidTransactionSignature,
-		helper.InvalidTransactionNonce,
-		helper.InvalidTransactionGas,
-		helper.InvalidTransactionGasPrice,
-		helper.InvalidTransactionValue,
-		// helper.InvalidOmmers, Unsupported now
-	} {
-		for _, reOrgFromCanonical := range []bool{false, true} {
-			invalidIndex := 9
-			if invalidField == helper.InvalidReceiptsRoot ||
-				invalidField == helper.InvalidGasLimit ||
-				invalidField == helper.InvalidGasUsed ||
-				invalidField == helper.InvalidTimestamp ||
-				invalidField == helper.InvalidPrevRandao {
-				invalidIndex = 8
-			}
-			if invalidField == helper.InvalidStateRoot {
+	/*
+		TODO: Tests are disabled since they rely on a Geth node (running within test process) for P2P communcation and block production. Possible fixes: 1: Somehow re-write the tests to use dockerized node; 2: Wait for Gnosis support for Geth.
+
+		spec := test.BaseSpec{
+			TimeoutSeconds:   60,
+			SlotsToSafe:      big.NewInt(32),
+			SlotsToFinalized: big.NewInt(64),
+		}
+		for _, invalidField := range []helper.InvalidPayloadBlockField{
+			helper.InvalidStateRoot,
+			helper.InvalidReceiptsRoot,
+			// TODO: helper.InvalidNumber, Test is causing a panic on the secondary node, disabling for now.
+			helper.InvalidGasLimit,
+			helper.InvalidGasUsed,
+			helper.InvalidTimestamp,
+			// TODO: helper.InvalidPrevRandao, Test consistently fails with Failed to set invalid block: missing trie node.
+			helper.RemoveTransaction,
+			helper.InvalidTransactionSignature,
+			helper.InvalidTransactionNonce,
+			helper.InvalidTransactionGas,
+			helper.InvalidTransactionGasPrice,
+			helper.InvalidTransactionValue,
+			// helper.InvalidOmmers, Unsupported now
+		} {
+			for _, reOrgFromCanonical := range []bool{false, true} {
+				invalidIndex := 9
+				if invalidField == helper.InvalidReceiptsRoot ||
+					invalidField == helper.InvalidGasLimit ||
+					invalidField == helper.InvalidGasUsed ||
+					invalidField == helper.InvalidTimestamp ||
+					invalidField == helper.InvalidPrevRandao {
+					invalidIndex = 8
+				}
+				if invalidField == helper.InvalidStateRoot {
+					Tests = append(Tests, InvalidMissingAncestorReOrgSyncTest{
+						BaseSpec:           spec,
+						InvalidField:       invalidField,
+						ReOrgFromCanonical: reOrgFromCanonical,
+						EmptyTransactions:  true,
+						InvalidIndex:       invalidIndex,
+					})
+				}
 				Tests = append(Tests, InvalidMissingAncestorReOrgSyncTest{
 					BaseSpec:           spec,
 					InvalidField:       invalidField,
 					ReOrgFromCanonical: reOrgFromCanonical,
-					EmptyTransactions:  true,
 					InvalidIndex:       invalidIndex,
 				})
 			}
-			Tests = append(Tests, InvalidMissingAncestorReOrgSyncTest{
-				BaseSpec:           spec,
-				InvalidField:       invalidField,
-				ReOrgFromCanonical: reOrgFromCanonical,
-				InvalidIndex:       invalidIndex,
-			})
 		}
-	}
+	*/
 
 	// Re-org using the Engine API tests
 

--- a/simulators/ethereum/gnosis-engine-jq/test/expect.go
+++ b/simulators/ethereum/gnosis-engine-jq/test/expect.go
@@ -804,10 +804,14 @@ func (tec *TestEngineClient) TestHeaderByNumber(number *big.Int) *HeaderResponse
 	ctx, cancel := context.WithTimeout(tec.TestContext, globals.RPCTimeout)
 	defer cancel()
 	header, err := tec.Engine.HeaderByNumber(ctx, number)
+	var blockHeader *types.Header = nil
+	if header != nil {
+		blockHeader = &header.Header
+	}
 	ret := &HeaderResponseExpectObject{
 		ExpectEnv: &ExpectEnv{Env: tec.Env},
 		Call:      "HeaderByNumber",
-		Header:    &header.Header,
+		Header:    blockHeader,
 		Error:     err,
 	}
 	if err, ok := err.(rpc.Error); ok {


### PR DESCRIPTION
- Enables engine api tests
- Fixes some of the issues with negative cases, which was't supported by the sim
- Disables Invalid Ancestor Re-Org tests


Invalid Ancestor Re-Org Tests:
They rely on running the Geth node in-place(starting the server directly via golang APIs). And since Geth is not supported on Gnosis, we can't make the tests work without re-writing them to use dockerized nethermind/erigon node.