### PR TITLE
Mocked SetTTDBlockClient function for Erigon

### DIFF
--- a/simulators/ethereum/engine-gnosis-erigon/clmock/clmock.go
+++ b/simulators/ethereum/engine-gnosis-erigon/clmock/clmock.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -274,21 +273,23 @@ func (cl *CLMocker) SetTTDBlockClient(ec client.EngineClient) {
 	}
 	cl.HeaderHistory[cl.LatestHeader.Number.Uint64()] = &cl.LatestHeader.Header
 
-	ctx, cancel = context.WithTimeout(cl.TestContext, globals.RPCTimeout)
-	defer cancel()
+	// ctx, cancel = context.WithTimeout(cl.TestContext, globals.RPCTimeout)
+	// defer cancel()
 
-	if td, err := ec.GetTotalDifficulty(ctx); err != nil {
-		cl.Fatalf("CLMocker: Error getting total difficulty from engine client: %v", err)
-		panic(err)
-	} else if td.Cmp(ec.TerminalTotalDifficulty()) < 0 {
-		cl.Fatalf("CLMocker: Attempted to set TTD Block when TTD had not been reached: %d > %d", ec.TerminalTotalDifficulty(), td)
-		panic(err)
-	} else {
-		cl.Logf("CLMocker: TTD has been reached at block %d (%d>=%d)\n", cl.LatestHeader.Number, td, ec.TerminalTotalDifficulty())
-		jsH, _ := json.MarshalIndent(cl.LatestHeader, "", " ")
-		cl.Logf("CLMocker: Client: %s, Block %d: %s\n", ec.ID(), cl.LatestHeader.Number, jsH)
-		cl.ChainTotalDifficulty = td
-	}
+	// TODO: Commented TotalDifficulty related things to remove it in the future
+
+	// if td, err := ec.GetTotalDifficulty(ctx); err != nil {
+	// 	cl.Fatalf("CLMocker: Error getting total difficulty from engine client: %v", err)
+	// 	panic(err)
+	// } else if td.Cmp(ec.TerminalTotalDifficulty()) < 0 {
+	// 	cl.Fatalf("CLMocker: Attempted to set TTD Block when TTD had not been reached: %d > %d", ec.TerminalTotalDifficulty(), td)
+	// 	panic(err)
+	// } else {
+	// 	cl.Logf("CLMocker: TTD has been reached at block %d (%d>=%d)\n", cl.LatestHeader.Number, td, ec.TerminalTotalDifficulty())
+	// 	jsH, _ := json.MarshalIndent(cl.LatestHeader, "", " ")
+	// 	cl.Logf("CLMocker: Client: %s, Block %d: %s\n", ec.ID(), cl.LatestHeader.Number, jsH)
+	// 	cl.ChainTotalDifficulty = td
+	// }
 
 	cl.TTDReached = true
 

--- a/simulators/ethereum/engine-gnosis-erigon/helper/helper.go
+++ b/simulators/ethereum/engine-gnosis-erigon/helper/helper.go
@@ -315,12 +315,14 @@ func WaitForTTD(ec client.EngineClient, wg *sync.WaitGroup, done chan<- WaitTTDR
 	for {
 		select {
 		case <-time.After(TTDCheckPeriod):
-			ttdReached, err := CheckTTD(ec, ctx)
-			if err == nil && ttdReached {
+			// ttdReached, err := CheckTTD(ec, ctx)
+			// TODO: Remove WaitForTTD in the future
+			ttdReached := true
+			if ttdReached {
 				select {
 				case done <- WaitTTDResponse{
 					ec:  ec,
-					err: err,
+					err: nil,
 				}:
 				case <-ctx.Done():
 				}


### PR DESCRIPTION
Recently Erigon team has removed totalDifficulty https://github.com/erigontech/erigon/pull/11809  from Block [schema](https://github.com/ethereum/execution-apis/pull/570) 

As expected, hive tests fail
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x52d522]

goroutine 67 [running]:
math/big.(*Int).Cmp(0xc0002ae500?, 0x1745608?)
	/usr/local/go/src/math/big/int.go:373 +0x22
github.com/ethereum/hive/simulators/ethereum/engine/helper.CheckTTD({0x1757f08, 0xc0002ae500}, {0x1745598?, 0xc00052c190?})
	/source/helper/helper.go:294 +0xe5
github.com/ethereum/hive/simulators/ethereum/engine/helper.WaitForTTD({0x1757f08, 0xc0002ae500}, 0xc0002d4000?, 0xc00028c420, {0x1745598?, 0xc00052c190?})
	/source/helper/helper.go:310 +0x12d
created by github.com/ethereum/hive/simulators/ethereum/engine/helper.WaitAnyClientForTTD
	/source/helper/helper.go:357 +0x1a5
```

In this PR I just mocked `WaitAnyClientForTTD` to fix the build and did not remove all TD related things because we do not know when Nethermind and other clients will remove it. We may wait until the changes will be applied to upstream and use similar way to update it.

Another approach is to use environment variables (in jq simulator) and turn on / turn off such features to specific clients.

As for now, the changes affects `ethereum/engine-gnosis-erigon` simulator only