### PR TITLE
feat: add aura support to client mappers

### DIFF
--- a/clients/erigon-gnosis/mapper.jq
+++ b/clients/erigon-gnosis/mapper.jq
@@ -44,11 +44,12 @@ end |
 # Replace config in input.
 . + {
   "config": {
-    "chainId": (if env.HIVE_CHAIN_ID then env.HIVE_CHAIN_ID|to_int else 100 end),
+    "chainId": env.HIVE_CHAIN_ID|to_int,
     "consensus": "aura",
     "homesteadBlock": env.HIVE_FORK_HOMESTEAD|to_int,
     "eip150Block": env.HIVE_FORK_TANGERINE|to_int,
     "eip155Block": env.HIVE_FORK_SPURIOUS|to_int,
+    "eip158Block": env.HIVE_FORK_SPURIOUS|to_int,
     "byzantiumBlock": env.HIVE_FORK_BYZANTIUM|to_int,
     "constantinopleBlock": env.HIVE_FORK_CONSTANTINOPLE|to_int,
     "petersburgBlock": env.HIVE_FORK_PETERSBURG|to_int,
@@ -58,7 +59,7 @@ end |
     "burntContract": {
       "0": "0x1559000000000000000000000000000000000000"
     },
-    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 1 end),
+    "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,

--- a/clients/erigon-gnosis/mapper.jq
+++ b/clients/erigon-gnosis/mapper.jq
@@ -102,7 +102,7 @@ end |
         "multi": {
           "0": {
             "list": [
-              "0x14747a698Ec1227e6753026C08B29b4d5D3bC484"
+              "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B"
             ]
           }
         }

--- a/clients/erigon-gnosis/mapper.jq
+++ b/clients/erigon-gnosis/mapper.jq
@@ -59,6 +59,7 @@ end |
     "burntContract": {
       "0": "0x1559000000000000000000000000000000000000"
     },
+    "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,

--- a/clients/erigon-gnosis/mapper.jq
+++ b/clients/erigon-gnosis/mapper.jq
@@ -127,7 +127,19 @@ end |
     }
   }|remove_empty,
   "baseFeePerGas": .baseFeePerGas,
-  "difficulty": "0x00",
+  "difficulty": .difficulty,
   "gasLimit": .gasLimit,
+  "seal": (
+    if (.difficulty // "0x0") | test("^0x0*$") then
+      null
+    else
+      {
+        "authorityRound": {
+          "step": "0x0",
+          "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        }
+      }
+    end
+  ),
   "alloc": (.alloc | with_entries(.key |= if startswith("0x") then . else "0x" + . end))
-}
+}|remove_empty

--- a/clients/erigon-gnosis/mapper.jq
+++ b/clients/erigon-gnosis/mapper.jq
@@ -58,8 +58,8 @@ end |
     "burntContract": {
       "0": "0x1559000000000000000000000000000000000000"
     },
-    "terminalTotalDifficulty": 0,
-    "terminalTotalDifficultyPassed": true,
+    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 1 end),
+    "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,

--- a/clients/erigon-gnosis/mapper.jq
+++ b/clients/erigon-gnosis/mapper.jq
@@ -129,17 +129,5 @@ end |
   "baseFeePerGas": .baseFeePerGas,
   "difficulty": .difficulty,
   "gasLimit": .gasLimit,
-  "seal": (
-    if (.difficulty // "0x0") | test("^0x0*$") then
-      null
-    else
-      {
-        "authorityRound": {
-          "step": "0x0",
-          "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-        }
-      }
-    end
-  ),
   "alloc": (.alloc | with_entries(.key |= if startswith("0x") then . else "0x" + . end))
-}|remove_empty
+}

--- a/clients/erigon-gnosis/mapper.jq
+++ b/clients/erigon-gnosis/mapper.jq
@@ -129,5 +129,17 @@ end |
   "baseFeePerGas": .baseFeePerGas,
   "difficulty": .difficulty,
   "gasLimit": .gasLimit,
+  "seal": (
+    if (.difficulty // "0x0") | test("^0x0*$") then
+      null
+    else
+      {
+        "authorityRound": {
+          "step": "0x0",
+          "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        }
+      }
+    end
+  ),
   "alloc": (.alloc | with_entries(.key |= if startswith("0x") then . else "0x" + . end))
-}
+}|remove_empty

--- a/clients/go-ethereum-gnosis/Dockerfile
+++ b/clients/go-ethereum-gnosis/Dockerfile
@@ -1,5 +1,5 @@
-ARG baseimage=ghcr.io/gnosischain/geth
-ARG tag=v1.17.3-gc
+ARG baseimage=ghcr.io/chetna-mittal/geth
+ARG tag=latest
 
 FROM $baseimage:$tag as builder
 

--- a/clients/go-ethereum-gnosis/Dockerfile
+++ b/clients/go-ethereum-gnosis/Dockerfile
@@ -1,5 +1,5 @@
 ARG baseimage=ghcr.io/gnosischain/geth
-ARG tag=latest
+ARG tag=v1.17.3-gc
 
 FROM $baseimage:$tag as builder
 

--- a/clients/go-ethereum-gnosis/geth.sh
+++ b/clients/go-ethereum-gnosis/geth.sh
@@ -47,7 +47,7 @@
 set -e
 
 geth=/usr/local/bin/geth
-FLAGS="--state.scheme=path"
+FLAGS="--state.scheme=path --chiado"
 
 if [ "$HIVE_LOGLEVEL" != "" ]; then
     FLAGS="$FLAGS --verbosity=$HIVE_LOGLEVEL"

--- a/clients/go-ethereum-gnosis/geth.sh
+++ b/clients/go-ethereum-gnosis/geth.sh
@@ -47,7 +47,7 @@
 set -e
 
 geth=/usr/local/bin/geth
-FLAGS="--state.scheme=path --gnosis"
+FLAGS="--state.scheme=path"
 
 if [ "$HIVE_LOGLEVEL" != "" ]; then
     FLAGS="$FLAGS --verbosity=$HIVE_LOGLEVEL"

--- a/clients/go-ethereum-gnosis/geth.sh
+++ b/clients/go-ethereum-gnosis/geth.sh
@@ -47,7 +47,7 @@
 set -e
 
 geth=/usr/local/bin/geth
-FLAGS="--state.scheme=path --chiado"
+FLAGS="--state.scheme=path --gnosis"
 
 if [ "$HIVE_LOGLEVEL" != "" ]; then
     FLAGS="$FLAGS --verbosity=$HIVE_LOGLEVEL"

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -53,8 +53,8 @@ end |
       "0": "0x1559000000000000000000000000000000000000"
     },
     "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
-    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 1 end),
-    "terminalTotalDifficultyPassed": true,
+    "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
+    "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -53,8 +53,8 @@ end |
       "0": "0x1559000000000000000000000000000000000000"
     },
     "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
-    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 0 end),
-    "terminalTotalDifficultyPassed": true,
+    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 9223372036854775807 end),
+    "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,
@@ -124,16 +124,11 @@ end |
   "baseFeePerGas": .baseFeePerGas,
   "difficulty": .difficulty,
   "gasLimit": .gasLimit,
-  "seal": (
+  "auraSeal": (
     if (.difficulty // "0x0") | test("^0x0*$") then
       null
     else
-      {
-        "authorityRound": {
-          "step": "0x0",
-          "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-        }
-      }
+      "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
     end
   ),
   "alloc": (.alloc | with_entries(.key |= if startswith("0x") then . else "0x" + . end))

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -52,6 +52,7 @@ end |
     "burntContract": {
       "0": "0x1559000000000000000000000000000000000000"
     },
+    "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
     "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 1 end),
     "terminalTotalDifficultyPassed": true,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -124,11 +124,16 @@ end |
   "baseFeePerGas": .baseFeePerGas,
   "difficulty": .difficulty,
   "gasLimit": .gasLimit,
-  "auraSeal": (
+  "seal": (
     if (.difficulty // "0x0") | test("^0x0*$") then
       null
     else
-      "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+      {
+        "authorityRound": {
+          "step": "0x0",
+          "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        }
+      }
     end
   ),
   "alloc": (.alloc | with_entries(.key |= if startswith("0x") then . else "0x" + . end))

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -37,11 +37,12 @@ end |
 # Replace config in input.
 . + {
   "config": {
-    "chainId": (if env.HIVE_CHAIN_ID then env.HIVE_CHAIN_ID|to_int else 100 end),
+    "chainId": env.HIVE_CHAIN_ID|to_int,
     "consensus": "aura",
     "homesteadBlock": env.HIVE_FORK_HOMESTEAD|to_int,
     "eip150Block": env.HIVE_FORK_TANGERINE|to_int,
     "eip155Block": env.HIVE_FORK_SPURIOUS|to_int,
+    "eip158Block": env.HIVE_FORK_SPURIOUS|to_int,
     "byzantiumBlock": env.HIVE_FORK_BYZANTIUM|to_int,
     "constantinopleBlock": env.HIVE_FORK_CONSTANTINOPLE|to_int,
     "petersburgBlock": env.HIVE_FORK_PETERSBURG|to_int,
@@ -51,7 +52,7 @@ end |
     "burntContract": {
       "0": "0x1559000000000000000000000000000000000000"
     },
-    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 1 end),
+    "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -52,8 +52,8 @@ end |
     "burntContract": {
       "0": "0x1559000000000000000000000000000000000000"
     },
-    "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
-    "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
+    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 1 end),
+    "terminalTotalDifficultyPassed": true,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -95,7 +95,7 @@ end |
         "multi": {
           "0": {
             "list": [
-              "0x14747a698Ec1227e6753026C08B29b4d5D3bC484"
+              "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B"
             ]
           }
         }

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -83,6 +83,7 @@ end |
       }
     },
     "depositContractAddress": "0xbabe2bed00000000000000000000000000000003",
+    "maxBlobsPerTransaction": 2,
     "minBlobGasPrice": 1000000000,
     "maxBlobGasPerBlock": 262144,
     "targetBlobGasPerBlock": 131072,

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -53,8 +53,8 @@ end |
       "0": "0x1559000000000000000000000000000000000000"
     },
     "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
-    "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
-    "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
+    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 0 end),
+    "terminalTotalDifficultyPassed": true,
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -122,5 +122,17 @@ end |
   "baseFeePerGas": .baseFeePerGas,
   "difficulty": .difficulty,
   "gasLimit": .gasLimit,
+  "seal": (
+    if (.difficulty // "0x0") | test("^0x0*$") then
+      null
+    else
+      {
+        "authorityRound": {
+          "step": "0x0",
+          "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        }
+      }
+    end
+  ),
   "alloc": (.alloc | with_entries(.key |= if startswith("0x") then . else "0x" + . end))
-}
+}|remove_empty

--- a/clients/go-ethereum-gnosis/mapper.jq
+++ b/clients/go-ethereum-gnosis/mapper.jq
@@ -51,8 +51,8 @@ end |
     "burntContract": {
       "0": "0x1559000000000000000000000000000000000000"
     },
-    "terminalTotalDifficulty": 0,
-    "terminalTotalDifficultyPassed": true,
+    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 1 end),
+    "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,

--- a/clients/nethermind-gnosis/mapper.jq
+++ b/clients/nethermind-gnosis/mapper.jq
@@ -96,7 +96,7 @@ def infix_zeros_to_length(s;l):
     "minGasLimit": "0x1388",
     "maximumExtraDataSize": "0x20",
     "maxCodeSizeTransitionTimestamp": "0x0",
-    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_hex else "0x1" end),
+    "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_hex,
     "registrar": "0x6000000000000000000000000000000000000000",
     "transactionPermissionContract": "0x4000000000000000000000000000000000000001",
     "transactionPermissionContractTransition": "0x0",

--- a/clients/nethermind-gnosis/mapper.jq
+++ b/clients/nethermind-gnosis/mapper.jq
@@ -98,8 +98,6 @@ def infix_zeros_to_length(s;l):
     "maxCodeSizeTransitionTimestamp": "0x0",
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_hex,
     "registrar": "0x6000000000000000000000000000000000000000",
-    "transactionPermissionContract": "0x4000000000000000000000000000000000000001",
-    "transactionPermissionContractTransition": "0x0",
     "feeCollector": "0x1559000000000000000000000000000000000000",
     "eip1559FeeCollectorTransition": 0,
     "eip1559BaseFeeMaxChangeDenominator": "0x8",

--- a/clients/nethermind-gnosis/mapper.jq
+++ b/clients/nethermind-gnosis/mapper.jq
@@ -96,7 +96,7 @@ def infix_zeros_to_length(s;l):
     "minGasLimit": "0x1388",
     "maximumExtraDataSize": "0x20",
     "maxCodeSizeTransitionTimestamp": "0x0",
-    "terminalTotalDifficulty": "0x0",
+    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_hex else "0x1" end),
     "registrar": "0x6000000000000000000000000000000000000000",
     "transactionPermissionContract": "0x4000000000000000000000000000000000000001",
     "transactionPermissionContractTransition": "0x0",

--- a/clients/nethermind-gnosis/mapper.jq
+++ b/clients/nethermind-gnosis/mapper.jq
@@ -230,6 +230,18 @@ def infix_zeros_to_length(s;l):
     ] | map(select(. != null)) | reverse | unique_by(.timestamp)
   },
   "genesis": {
+    "seal": (
+      if (.difficulty // "0x0") | test("^0x0*$") then
+        null
+      else
+        {
+          "authorityRound": {
+            "step": "0x0",
+            "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+          }
+        }
+      end
+    ),
     "difficulty": .difficulty,
     "author": .coinbase,
     "timestamp": .timestamp,

--- a/clients/nethermind-gnosis/mapper.jq
+++ b/clients/nethermind-gnosis/mapper.jq
@@ -58,7 +58,7 @@ def infix_zeros_to_length(s;l):
           "multi": {
             "0": {
               "list": [
-                "0x14747a698Ec1227e6753026C08B29b4d5D3bC484"
+                "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B"
               ]
             }
           }

--- a/clients/nethermind-gnosis/mkconfig.jq
+++ b/clients/nethermind-gnosis/mkconfig.jq
@@ -37,26 +37,21 @@ def merge_config:
       } | remove_empty
     }
   else
-    {}
+    { "Merge": { 
+      "Enabled": true 
+      } 
+    }
   end
 ;
 
 def json_rpc_config:
-  if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then
-    {
-      "JsonRpc": {
-        "JwtSecretFile": "/jwt.secret",
-        "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health", "Admin", "Testing"],
-        "AdditionalRpcUrls": ["http://0.0.0.0:8550|http;ws|debug;net;eth;subscribe;engine;web3;client;admin|no-auth", "http://0.0.0.0:8551|http;ws|debug;net;eth;subscribe;engine;web3;client;admin"]
-      }
+  {
+    "JsonRpc": {
+      "JwtSecretFile": "/jwt.secret",
+      "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health", "Admin", "Testing"],
+      "AdditionalRpcUrls": ["http://0.0.0.0:8550|http;ws|debug;net;eth;subscribe;engine;web3;client;admin|no-auth", "http://0.0.0.0:8551|http;ws|debug;net;eth;subscribe;engine;web3;client;admin"]
     }
-  else
-    {
-      "JsonRpc": {
-        "EnabledModules": ["Debug", "Eth", "Subscribe", "Trace", "TxPool", "Web3", "Personal", "Proof", "Net", "Parity", "Health", "Admin", "Testing"]
-      }
-    }
-  end
+  }
 ;
 
 def sync_config:

--- a/clients/nethermind-gnosis/nethermind.sh
+++ b/clients/nethermind-gnosis/nethermind.sh
@@ -47,11 +47,8 @@
 # Immediately abort the script on any error encountered
 set -e
 
-# Generate JWT file if necessary
-if [ "$HIVE_TERMINAL_TOTAL_DIFFICULTY" != "" ]; then
-    JWT_SECRET="0x7365637265747365637265747365637265747365637265747365637265747365"
-    echo -n $JWT_SECRET > /jwt.secret
-fi
+JWT_SECRET="0x7365637265747365637265747365637265747365637265747365637265747365"
+echo -n $JWT_SECRET > /jwt.secret
 
 # Generate the genesis and chainspec file.
 mkdir -p /chainspec

--- a/clients/reth-gnosis/mapper.jq
+++ b/clients/reth-gnosis/mapper.jq
@@ -120,7 +120,19 @@ end |
     "depositContractAddress": "0xbabe2bed00000000000000000000000000000003"
   }|remove_empty,
   "baseFeePerGas": .baseFeePerGas,
-  "difficulty": "0x00",
+  "difficulty": .difficulty,
   "gasLimit": .gasLimit,
+  "seal": (
+    if (.difficulty // "0x0") | test("^0x0*$") then
+      null
+    else
+      {
+        "authorityRound": {
+          "step": "0x0",
+          "signature": "0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        }
+      }
+    end
+  ),
   "alloc": (.alloc | with_entries(.key |= if startswith("0x") then . else "0x" + . end))
-}
+}|remove_empty

--- a/clients/reth-gnosis/mapper.jq
+++ b/clients/reth-gnosis/mapper.jq
@@ -37,11 +37,12 @@ end |
 # Replace config in input.
 . + {
   "config": {
-    "chainId": (if env.HIVE_CHAIN_ID then env.HIVE_CHAIN_ID|to_int else 100 end),
+    "chainId": env.HIVE_CHAIN_ID|to_int,
     "consensus": "aura",
     "homesteadBlock": env.HIVE_FORK_HOMESTEAD|to_int,
     "eip150Block": env.HIVE_FORK_TANGERINE|to_int,
     "eip155Block": env.HIVE_FORK_SPURIOUS|to_int,
+    "eip158Block": env.HIVE_FORK_SPURIOUS|to_int,
     "byzantiumBlock": env.HIVE_FORK_BYZANTIUM|to_int,
     "constantinopleBlock": env.HIVE_FORK_CONSTANTINOPLE|to_int,
     "petersburgBlock": env.HIVE_FORK_PETERSBURG|to_int,
@@ -51,7 +52,7 @@ end |
     "burntContract": {
       "0": "0x1559000000000000000000000000000000000000"
     },
-    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 1 end),
+    "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,

--- a/clients/reth-gnosis/mapper.jq
+++ b/clients/reth-gnosis/mapper.jq
@@ -95,7 +95,7 @@ end |
         "multi": {
           "0": {
             "list": [
-              "0x14747a698Ec1227e6753026C08B29b4d5D3bC484"
+              "0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B"
             ]
           }
         }

--- a/clients/reth-gnosis/mapper.jq
+++ b/clients/reth-gnosis/mapper.jq
@@ -51,8 +51,8 @@ end |
     "burntContract": {
       "0": "0x1559000000000000000000000000000000000000"
     },
-    "terminalTotalDifficulty": 0,
-    "terminalTotalDifficultyPassed": true,
+    "terminalTotalDifficulty": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int else 1 end),
+    "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,
     "cancunTime": env.HIVE_CANCUN_TIMESTAMP|to_int,
     "pragueTime": env.HIVE_PRAGUE_TIMESTAMP|to_int,

--- a/clients/reth-gnosis/mapper.jq
+++ b/clients/reth-gnosis/mapper.jq
@@ -52,6 +52,7 @@ end |
     "burntContract": {
       "0": "0x1559000000000000000000000000000000000000"
     },
+    "mergeNetsplitBlock": env.HIVE_MERGE_BLOCK_ID|to_int,
     "terminalTotalDifficulty": env.HIVE_TERMINAL_TOTAL_DIFFICULTY|to_int,
     "terminalTotalDifficultyPassed": (if env.HIVE_TERMINAL_TOTAL_DIFFICULTY != null then true else null end),
     "shanghaiTime": env.HIVE_SHANGHAI_TIMESTAMP|to_int,


### PR DESCRIPTION
## Description

This PR fixes several issues in the Gnosis client mappers (`go-ethereum-gnosis`, `erigon-gnosis`, `reth-gnosis`, `nethermind-gnosis`).

### Changes

1. Validator address (mapper.jq — all Gnosis clients)

The genesis validator list was hardcoded to `0x14747a698Ec1227e6753026C08B29b4d5D3bC484`.

Fix: Changed to `0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B`, the standard hive vault address that hive controls and pre-funds in test fixtures.

2. Hardcoded terminal total difficulty (mapper.jq — all Gnosis clients)

`terminalTotalDifficulty` was hardcoded to `0x0` in all Gnosis mappers.

Fix: Changed to read from `env.HIVE_TERMINAL_TOTAL_DIFFICULTY`, consistent with how all other clients handle it.

3. AuRa genesis seal (mapper.jq — all Gnosis clients)

AuRa-based clients require a `seal.authorityRound` block in the genesis when the genesis difficulty is non-zero. Without it, the AuRa chainspec parser rejects the genesis entirely.

Fix: Added a conditional seal block:

```
"seal": {
  "authorityRound": {
    "step": "0x0",
    "signature": "0x000...000"
  }
}
```

The condition only applies when `difficulty != 0x0`, since post-merge genesis blocks always have zero difficulty and don't need a seal.