### PR TITLE
chore: update go-ethereum client image

### DIFF
--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -1,5 +1,5 @@
 ARG baseimage=ghcr.io/adityasripal/geth
-ARG tag=v1.17.4-gc.1
+ARG tag=v1.17.4-gc
 
 FROM $baseimage:$tag as builder
 

--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -1,5 +1,5 @@
 ARG baseimage=ghcr.io/adityasripal/geth
-ARG tag=v1.17.4-gc
+ARG tag=v1.17.4-gc.1
 
 FROM $baseimage:$tag as builder
 

--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -1,5 +1,5 @@
-ARG baseimage=ghcr.io/chetna-mittal/geth
-ARG tag=latest
+ARG baseimage=ghcr.io/adityasripal/geth
+ARG tag=v1.17.4-gc
 
 FROM $baseimage:$tag as builder
 

--- a/clients/go-ethereum/Dockerfile
+++ b/clients/go-ethereum/Dockerfile
@@ -1,5 +1,5 @@
-ARG baseimage=ghcr.io/adityasripal/geth
-ARG tag=v1.17.4-gc.1
+ARG baseimage=ghcr.io/gnosischain/geth
+ARG tag=latest
 
 FROM $baseimage:$tag as builder
 

--- a/clients/go-ethereum/Dockerfile.git
+++ b/clients/go-ethereum/Dockerfile.git
@@ -2,7 +2,7 @@
 
 FROM golang:1.24-alpine as builder
 ARG github=gnosischain/go-ethereum
-ARG tag=master
+ARG tag=release-1.17.3-gc
 ARG GOPROXY
 
 ENV GOPROXY=${GOPROXY}


### PR DESCRIPTION
## Description

Update `go-ethereum` client image to `gnosischain/geth:latest` image.